### PR TITLE
docs: add screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Evidence-based sprint retrospectives for human-agent collaboration. **No AI slop
 
 ## What Makes This Different
 
+![Agentic Retrospective Screenshot](assets/retrospective-screen.png)
+
 Most retrospective tools produce vague observations like "58 tool invocations across 7 tools". That's useless.
 
 This tool produces **objective, evidence-based metrics**:


### PR DESCRIPTION
## Summary
- Adds `assets/retrospective-screen.png` to README under "What Makes This Different"
- Shows users what the tool produces before they install

## Test plan
- [ ] Verify image renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)