### PR TITLE
feat: prepare package for npm publishing as @daax-dev/retrospective

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,22 @@
+# Source and config
+src/
+tsconfig.json
+vitest.config.ts
+eslint.config.mjs
+
+# Development
+.progress/
+test/
+coverage/
+*.tgz
+
+# Docs (keep only README)
+docs/building/
+docs/completed/
+CLAUDE.md
+AGENTSKILLS.md
+plugin.json
+
+# Git
+.git/
+.gitignore

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agentic Retrospective
 
+[![npm version](https://img.shields.io/npm/v/@daax-dev/retrospective.svg)](https://www.npmjs.com/package/@daax-dev/retrospective)
+[![npm downloads](https://img.shields.io/npm/dm/@daax-dev/retrospective.svg)](https://www.npmjs.com/package/@daax-dev/retrospective)
 [![AgentSkills](https://img.shields.io/badge/AgentSkills-compatible-blue)](https://agentskills.io)
 
 Evidence-based sprint retrospectives for human-agent collaboration. **No AI slop** - every finding links to specific commits, PRs, or decisions.
@@ -48,22 +50,24 @@ Top Tools: Bash (39), Glob (6), Read (4)
 
 ## Installation
 
-### npx (no install)
+### Quick run (no install)
 
 ```bash
-npx agentic-retrospective
+npx @daax-dev/retrospective
 ```
 
-### npm global
+### Global install
 
 ```bash
-npm install -g agentic-retrospective
+npm install -g @daax-dev/retrospective
+# Then run:
+agentic-retrospective
 ```
 
-### Claude Code Plugin
+### As Claude Code Plugin
 
 ```bash
-claude /plugin add daax-dev/agentic-retrospective
+claude mcp install github.com/daax-dev/agentic-retrospective
 ```
 
 ## Usage
@@ -72,20 +76,20 @@ claude /plugin add daax-dev/agentic-retrospective
 
 ```bash
 # Analyze last 2 weeks (default)
-npx agentic-retrospective
+npx @daax-dev/retrospective
 
 # Analyze from specific ref
-npx agentic-retrospective --from HEAD~50
-npx agentic-retrospective --from "2 weeks ago"
+npx @daax-dev/retrospective --from HEAD~50
+npx @daax-dev/retrospective --from "2 weeks ago"
 
 # Output JSON only
-npx agentic-retrospective --json
+npx @daax-dev/retrospective --json
 ```
 
 ### Session Feedback
 
 ```bash
-npx agentic-retrospective feedback
+npx @daax-dev/retrospective feedback
 ```
 
 30-second survey to capture alignment, rework needed, and session quality.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentic/retrospective",
+  "name": "@daax-dev/retrospective",
   "version": "0.1.0",
   "description": "Agentic Retrospective - Evidence-based sprint retrospectives for human-agent collaboration",
   "author": "JP Workspace",
@@ -10,6 +10,13 @@
   "bin": {
     "agentic-retrospective": "dist/cli.js"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
     "commands",
@@ -18,6 +25,9 @@
     "examples",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -66,7 +76,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jpoley/agentic-retrospective.git",
-    "directory": "tools/retrospective"
+    "url": "https://github.com/daax-dev/agentic-retrospective.git"
   }
 }


### PR DESCRIPTION
## Summary

- Change package name from `@agentic/retrospective` to `@daax-dev/retrospective`
- Add `publishConfig` with `access: public` for scoped package
- Add `exports` field for proper ESM module resolution
- Update repository URL to `github.com/daax-dev/agentic-retrospective`
- Update README install instructions for new package name
- Add npm version and downloads badges
- Add `.npmignore` to exclude source, tests, and dev files from tarball

## Pre-publish checklist

After merge, the following steps are needed to publish:

1. **Claim npm organization** (one-time): Create `daax-dev` org at https://www.npmjs.com/org/create
2. **Login to npm**: `npm login`
3. **Run validation**: `pnpm run validate`
4. **Build**: `pnpm run build`
5. **Dry run**: `npm publish --dry-run`
6. **Publish**: `npm publish`

## Test plan

- [x] `pnpm run validate` passes (265 tests)
- [x] `npm pack --dry-run` shows expected files only
- [x] Tarball excludes: `src/`, `test/`, `.progress/`, `docs/building/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)