### PR TITLE
feat: prepare package for npm publishing as @daax-dev/retrospective

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run validation
+        run: pnpm run validate
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Check if version changed
+        id: version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          NPM_VERSION=$(npm view @daax-dev/retrospective version 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT_VERSION" != "$NPM_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Version changed: $NPM_VERSION -> $CURRENT_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Version unchanged: $CURRENT_VERSION"
+          fi
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,40 @@
+# Source and config
+src/
+tsconfig.json
+vitest.config.ts
+.eslintrc.json
+
+# Lock files
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Development
+.progress/
+test/
+test-output/
+coverage/
+*.tgz
+
+# Development directories
+.github/
+.claude/
+.claude-plugin/
+hooks/
+memory/
+references/
+scripts/
+skills/
+assets/
+
+# Docs - only specific files in package.json files field are included
+# No need to exclude here since we're explicit in files field
+
+# Config and metadata
+CLAUDE.md
+AGENTSKILLS.md
+plugin.json
+
+# Git
+.git/
+.gitignore

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agentic Retrospective
 
+[![npm version](https://img.shields.io/npm/v/@daax-dev/retrospective.svg)](https://www.npmjs.com/package/@daax-dev/retrospective)
+[![npm downloads](https://img.shields.io/npm/dm/@daax-dev/retrospective.svg)](https://www.npmjs.com/package/@daax-dev/retrospective)
 [![AgentSkills](https://img.shields.io/badge/AgentSkills-compatible-blue)](https://agentskills.io)
 
 Evidence-based sprint retrospectives for human-agent collaboration. **No AI slop** - every finding links to specific commits, PRs, or decisions.
@@ -50,22 +52,24 @@ Top Tools: Bash (39), Glob (6), Read (4)
 
 ## Installation
 
-### npx (no install)
+### Quick run (no install)
 
 ```bash
-npx agentic-retrospective
+npx @daax-dev/retrospective
 ```
 
-### npm global
+### Global install
 
 ```bash
-npm install -g agentic-retrospective
+npm install -g @daax-dev/retrospective
+# Then run:
+agentic-retrospective
 ```
 
-### Claude Code Plugin
+### As Claude Code Plugin
 
 ```bash
-claude /plugin add daax-dev/agentic-retrospective
+claude mcp install github.com/daax-dev/agentic-retrospective
 ```
 
 ## Usage
@@ -74,20 +78,20 @@ claude /plugin add daax-dev/agentic-retrospective
 
 ```bash
 # Analyze last 2 weeks (default)
-npx agentic-retrospective
+npx @daax-dev/retrospective
 
 # Analyze from specific ref
-npx agentic-retrospective --from HEAD~50
-npx agentic-retrospective --from "2 weeks ago"
+npx @daax-dev/retrospective --from HEAD~50
+npx @daax-dev/retrospective --from "2 weeks ago"
 
 # Output JSON only
-npx agentic-retrospective --json
+npx @daax-dev/retrospective --json
 ```
 
 ### Session Feedback
 
 ```bash
-npx agentic-retrospective feedback
+npx @daax-dev/retrospective feedback
 ```
 
 30-second survey to capture alignment, rework needed, and session quality.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentic/retrospective",
+  "name": "@daax-dev/retrospective",
   "version": "0.1.0",
   "description": "Agentic Retrospective - Evidence-based sprint retrospectives for human-agent collaboration",
   "author": "JP Workspace",
@@ -10,14 +10,25 @@
   "bin": {
     "agentic-retrospective": "dist/cli.js"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
     "commands",
     "schemas",
-    "docs",
+    "docs/TESTING.md",
+    "docs/fixing-telemetry-gaps.md",
     "examples",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -66,7 +77,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jpoley/agentic-retrospective.git",
-    "directory": "tools/retrospective"
+    "url": "https://github.com/daax-dev/agentic-retrospective.git"
   }
 }


### PR DESCRIPTION
## Summary

Prepares the package for npm publishing with automated CI/CD.

### Package Changes
- Change name from `@agentic/retrospective` to `@daax-dev/retrospective`
- Add `publishConfig` with `access: public` for scoped package
- Add `exports` field for proper ESM module resolution
- Update repository URL to `github.com/daax-dev/agentic-retrospective`
- Specify exact doc files in files field (exclude generated retrospectives)

### Documentation
- Add npm version and downloads badges to README
- Update all install instructions for new scoped package name
- Update npx commands throughout README

### CI/CD
- Add GitHub Actions workflow to automatically publish on version change
- Workflow runs validation, builds, and publishes with npm provenance
- Only publishes when package.json version differs from npm registry

### .npmignore (addresses Copilot review feedback)
- Use `.eslintrc.json` (not `eslint.config.mjs`)
- Exclude lock files (`package-lock.json`, `pnpm-lock.yaml`)
- Exclude dev directories (`.github`, `.claude`, `test-output`, etc.)
- Exclude `docs/retrospectives/` (generated output)

## Pre-merge checklist

1. **Create npm organization** (one-time): Create `daax-dev` org at https://www.npmjs.com/org/create
2. **Add NPM_TOKEN secret**: Settings → Secrets → Actions → Add `NPM_TOKEN`

## Test plan

- [x] `pnpm run validate` passes (265 tests)
- [x] `npm pack --dry-run` shows 69 files (down from 77)
- [x] Tarball excludes: `src/`, `test/`, `.progress/`, `docs/retrospectives/`, lock files

🤖 Generated with [Claude Code](https://claude.com/claude-code)