### PR TITLE
fix: add fetch-depth: 0 for CI tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for e2e tests
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Tests failed because GitHub Actions does a shallow clone (depth 1), but e2e tests need `HEAD~20`.

Adds `fetch-depth: 0` to checkout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)