### PR TITLE
fix: build before running tests in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run validation
-        run: pnpm run validate
-
       - name: Build
         run: pnpm run build
+
+      - name: Run validation
+        run: pnpm run validate
 
       - name: Check if version changed
         id: version


### PR DESCRIPTION
CLI tests need dist/cli.js which is created by build. Move build step before validation.