### PR TITLE
docs: implementation plans for #18, #19, and skills best-practices

### DIFF
--- a/docs/plans/issue-18-plan.md
+++ b/docs/plans/issue-18-plan.md
@@ -1,0 +1,267 @@
+# Issue #18 Implementation Plan
+
+**Issue**: [daax-dev/agentic-retrospective#18 — Feature suggestions from a real-world automated integration](https://github.com/daax-dev/agentic-retrospective/issues/18)
+**Scope**: Three independent fixes — trend tracking, evidence_refs validation warning, adapter docs.
+**Branch**: `18-feature-integration-suggestions`
+**Derived from**: [`docs/updates.md`](../updates.md) §"Fix Plan: Issue #18"
+
+---
+
+## Objective
+
+Deliver three small, independently testable improvements reported by @DMokong while running v0.1.3 headless:
+
+1. **18-A**: Persist per-run score snapshots to enable multi-sprint trend detection.
+2. **18-B**: Emit a warning when `evidence_refs` contain entries with no recognized prefix (currently silently orphaned).
+3. **18-C**: Document the `commit:<hash>` `evidence_refs` format and how to correlate issue-tracker records.
+
+All three can ship in a single PR since they share the same contributor request, but each has its own acceptance criteria.
+
+---
+
+## Fix 18-A: Multi-Sprint Trend Tracking
+
+### Files
+
+| File | Change |
+|------|--------|
+| `src/types.ts` (after line 507, `RetroConfig`) | Add `SprintHistoryEntry` interface |
+| `src/runner.ts` line 8 | Add `appendFileSync` to fs destructure |
+| `src/runner.ts` line 9 | Add `resolve` to path destructure |
+| `src/runner.ts` inside `writeOutputs()` (near line 1086) | Add private `appendToHistory(report)` and invoke it |
+
+### New type (`src/types.ts`)
+
+```typescript
+export interface SprintHistoryEntry {
+  sprint_id: string;
+  date: string;               // ISO 8601
+  scores: Scores;
+  data_completeness: number;  // 0–100 percentage
+}
+```
+
+### New method (`src/runner.ts`)
+
+```typescript
+private appendToHistory(report: RetroReport): void {
+  const historyPath = resolve(this.config.outputDir, '../.retro-history.jsonl');
+  const entry: SprintHistoryEntry = {
+    sprint_id: report.sprint_id,
+    date: report.generated_at,
+    scores: report.scores,
+    data_completeness: report.data_completeness.percentage,
+  };
+  appendFileSync(historyPath, JSON.stringify(entry) + '\n', 'utf8');
+}
+```
+
+Call site: inside `writeOutputs()` immediately after the markdown write, before `return outputPath`.
+
+### Location rationale
+
+`resolve(outputDir, '../.retro-history.jsonl')` sits one level **above** the per-sprint output dirs, so a single history file spans all sprints. `resolve()` (not `join`) is required because `outputDir` defaults to a relative path (`docs/retrospectives`) — `join('../..')` on relative paths depends on `process.cwd()`.
+
+### Acceptance criteria
+
+- [ ] `SprintHistoryEntry` exported from `src/types.ts`.
+- [ ] First run creates `<outputDir>/../.retro-history.jsonl` with exactly one JSONL line.
+- [ ] Second run with a different `sprint_id` appends a second line; file still valid JSONL.
+- [ ] `--json` mode still writes history (silent).
+- [ ] `--quiet` mode still writes history.
+- [ ] Existing single-run tests still pass unchanged.
+
+### Tests (`test/history.test.ts` — new file)
+
+```
+describe('sprint history', () => {
+  it('creates history file on first run', async () => { /* ... */ });
+  it('appends entry on each run', async () => { /* two runs → two lines */ });
+  it('entry is valid JSON with required fields', async () => { /* ... */ });
+});
+```
+
+Mock `appendFileSync` via vitest `vi.mock('fs', ...)` OR use a tmp `outputDir` and read the real file.
+
+---
+
+## Fix 18-B: Evidence-Refs Validation Warning
+
+### Root cause
+
+`src/runner.ts:625–685` — `buildEvidenceMap()` only links refs matching `/commit:(\w+)/`. Two silent failure modes:
+
+1. Any prefix other than `commit:` produces no link and no warning.
+2. The regex `\w+` captures a hash of any length, but the lookup `map.commits[match[1]]` requires an **exact** match against the full 40-char hash indexed at line 638. Short hashes (e.g., `commit:a1b2c3d`) never match even when the commit exists in the period.
+
+### Files
+
+| File | Change |
+|------|--------|
+| `src/runner.ts:625` (`buildEvidenceMap`) | Add unknown-prefix detection + warning, short-hash index, TelemetryGap |
+
+### Implementation
+
+```typescript
+private buildEvidenceMap(data: CollectedData): EvidenceMap {
+  const VALID_PREFIXES = ['commit:', 'decision:', 'pr:', 'file:', 'inferred:'];
+  const unrecognizedRefs: string[] = [];
+
+  // Short-hash → full-hash index so `commit:a1b2c3d` resolves correctly.
+  const shortHashIndex = new Map<string, string>();
+  if (data.git?.commits) {
+    for (const c of data.git.commits) {
+      for (let len = 7; len <= Math.min(12, c.hash.length); len++) {
+        shortHashIndex.set(c.hash.slice(0, len), c.hash);
+      }
+    }
+  }
+
+  if (data.decisions?.records) {
+    for (const decision of data.decisions.records) {
+      for (const ref of (decision.evidence_refs || [])) {
+        if (!VALID_PREFIXES.some(p => ref.startsWith(p))) {
+          unrecognizedRefs.push(`decision ${decision.id || '?'}: "${ref}"`);
+        }
+      }
+    }
+  }
+
+  if (unrecognizedRefs.length > 0) {
+    process.stderr.write(
+      `[WARN] ${unrecognizedRefs.length} evidence_ref(s) have unrecognized format and will be orphaned:\n`
+    );
+    unrecognizedRefs.slice(0, 5).forEach(r => process.stderr.write(`  - ${r}\n`));
+    process.stderr.write(
+      '  Valid formats: commit:<hash>, pr:<number>, decision:<id>, file:<path>, inferred:<reason>\n'
+    );
+    this.addTelemetryGap({
+      gap_type: 'unrecognized_evidence_refs',
+      severity: 'medium',
+      impact: `${unrecognizedRefs.length} evidence_refs have unrecognized format and will not link to any artifact`,
+      recommendation:
+        'Use prefixed formats: commit:<hash>, pr:<number>, decision:<id>, file:<path>. See docs/fixing-telemetry-gaps.md.',
+    });
+  }
+
+  // ... existing map init continues. Replace:
+  //   if (match && map.commits[match[1]]) {
+  // with:
+  //   const resolvedHash = shortHashIndex.get(match[1]) ?? match[1];
+  //   if (match && map.commits[resolvedHash]) {
+  //     map.commits[resolvedHash].decisions.push(id);
+  //     map.decisions[id].commits.push(resolvedHash);
+  //   }
+}
+```
+
+### Output channel
+
+Warnings go to **stderr** because `--json` routes stdout to consumers; interleaving warnings would corrupt machine-readable output.
+
+### Acceptance criteria
+
+- [ ] A decision with `evidence_refs: ["claw-abc", "ISSUE-123"]` produces a stderr warning listing both refs.
+- [ ] A `TelemetryGap` with `gap_type: "unrecognized_evidence_refs"` is added to the report.
+- [ ] The decision still appears in `orphans.decisions_without_implementation`.
+- [ ] A decision with `evidence_refs: ["commit:a1b2c3d"]` (short hash) correctly resolves to the full hash when that commit exists in the analyzed period.
+- [ ] A decision with `evidence_refs: ["commit:<full-40>"]` continues to work (no regression).
+- [ ] `--json` stdout remains valid JSON — no warning bleed onto stdout.
+
+### Tests (`test/evidence-map.test.ts` — extend or new)
+
+```
+describe('buildEvidenceMap evidence_refs validation', () => {
+  it('warns on unrecognized prefix', () => { /* spy process.stderr.write */ });
+  it('adds TelemetryGap for unrecognized refs', () => { /* ... */ });
+  it('resolves short commit hashes to full hash', () => { /* ... */ });
+  it('does not warn when all refs use valid prefixes', () => { /* ... */ });
+  it('does not corrupt stdout under --json', () => { /* ... */ });
+});
+```
+
+---
+
+## Fix 18-C: Adapter Documentation
+
+### File
+
+`docs/fixing-telemetry-gaps.md` — append a new section (do not create a new file; users are already directed here for telemetry issues).
+
+### Content to append
+
+```markdown
+## Linking Issue Tracker Records to Git Commits (evidence_refs)
+
+The `evidence_refs` field links a decision to specific artifacts. Every ref must use a recognized prefix:
+
+| Prefix | Format | Links to |
+|--------|--------|----------|
+| `commit:` | `commit:<full-or-short-hash>` | A git commit |
+| `pr:` | `pr:<number>` | A GitHub pull request |
+| `decision:` | `decision:<id>` | Another decision record |
+| `file:` | `file:<relative-path>` | A source file |
+| `inferred:` | `inferred:<reason>` | Marks inferred evidence (no artifact) |
+
+### Correlating an Issue Tracker Record
+
+To link a decision to the commit that resolves a Linear/Jira issue:
+
+1. Find the git commit: `git log --oneline --grep="ISSUE-123"`
+2. Use the commit hash in `evidence_refs`:
+
+```json
+{
+  "ts": "2026-03-15T10:30:00Z",
+  "decision": "Adopted optimistic locking for inventory updates",
+  "rationale": "Reduces contention under concurrent write load",
+  "evidence_refs": ["commit:a1b2c3d", "pr:47"]
+}
+```
+
+**Common mistake**: Using raw issue IDs (`"ISSUE-123"`, `"claw-abc"`) directly. These have no recognized prefix and are silently orphaned. Always resolve to a `commit:` or `pr:` reference before logging.
+```
+
+### Acceptance criteria
+
+- [ ] Section appended to `docs/fixing-telemetry-gaps.md` with the prefix table and a JSON example.
+- [ ] Example decision record validates against `schemas/` decision schema (if one exists — verify).
+- [ ] Markdown renders correctly on GitHub (no broken code fences).
+
+---
+
+## Rollout
+
+| Priority | Fix | Effort | Risk |
+|----------|-----|--------|------|
+| 1 | 18-B (warning) | S | None — additive warning |
+| 2 | 18-C (docs) | XS | None |
+| 3 | 18-A (history) | M | Low — additive file write |
+
+All three in one PR, each as a separate commit so they can be reverted independently.
+
+## Validation
+
+Before opening PR:
+
+```bash
+pnpm run validate   # lint + typecheck + test (per package.json)
+pnpm run build      # confirms tsc passes
+# Smoke test: run against this repo itself
+node dist/cli.js --from HEAD~10 --output /tmp/retro-test
+cat /tmp/.retro-history.jsonl   # should show one line
+```
+
+## Out of Scope
+
+- Trend detection algorithm (improving/declining/stable) — only persistence is in #18. Analysis/presentation of trends is a separate feature.
+- Auto-migration of existing orphaned decision logs. Users keep existing logs; new runs surface warnings.
+- Schema changes to `DecisionRecord`. `evidence_refs` remains `string[]`.
+
+## References
+
+- `src/runner.ts:625–685` — `buildEvidenceMap()` implementation
+- `src/runner.ts:1055–1089` — `writeOutputs()` call site
+- `src/types.ts:499–507` — `RetroConfig`
+- `docs/fixing-telemetry-gaps.md` — adapter docs location
+- [`docs/updates.md`](../updates.md) — source plan

--- a/docs/plans/issue-19-plan.md
+++ b/docs/plans/issue-19-plan.md
@@ -1,0 +1,379 @@
+# Issue #19 Implementation Plan
+
+**Issue**: [daax-dev/agentic-retrospective#19 — Multi-repo support for team retrospectives](https://github.com/daax-dev/agentic-retrospective/issues/19)
+**Scope**: Optional `.retro.toml` config + `--repo` flag(s) enabling per-repo sections and an aggregate summary.
+**Branch**: `19-multi-repo-support`
+**Derived from**: [`docs/updates.md`](../updates.md) §"Fix Plan: Issue #19"
+
+---
+
+## Objective
+
+Support retrospectives across multiple repositories without breaking the single-repo default. Teams typically work across several repos; a retro for one repo misses cross-repo rework chains, scattered hotspots, and skewed fix-to-feature ratios.
+
+**Zero breaking changes.** Single-repo users with no `.retro.toml` and no `--repo` flag see identical behaviour.
+
+---
+
+## Behaviour Matrix
+
+| Input | Behaviour |
+|-------|-----------|
+| No `.retro.toml`, no `--repo` | Current behaviour — analyze `cwd`. |
+| `.retro.toml` with no `[[repos]]` | Sprint metadata from config, single-repo mode on `cwd`. |
+| `.retro.toml` with one or more `[[repos]]` | Multi-repo mode using config's repo list. |
+| `--repo ../other` | Analyze `../other` instead of `cwd`. |
+| `--repo ./a --repo ./b` | Multi-repo mode, per-repo sections + unified summary. |
+| `--repo` flags + `.retro.toml` | CLI `--repo` flags **override** config repos. |
+
+---
+
+## Phase 19-A: Type System
+
+### File: `src/types.ts`
+
+Add before `RetroConfig`:
+
+```typescript
+export interface RepoConfig {
+  path: string;    // Absolute or relative; resolved at runtime
+  label: string;   // Human-readable label used in reports (e.g., "frontend")
+}
+```
+
+Update `RetroConfig` (line 499–507) to add:
+
+```typescript
+repos?: RepoConfig[];   // Empty/absent = single-repo (cwd)
+```
+
+### Acceptance
+
+- [ ] `RepoConfig` exported.
+- [ ] `RetroConfig.repos` is optional; existing callers unchanged.
+- [ ] `pnpm run typecheck` passes.
+
+---
+
+## Phase 19-B: `.retro.toml` Discovery
+
+### New file: `src/config.ts`
+
+```typescript
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { parse } from '@iarna/toml';
+
+export interface RetroToml {
+  retrospective?: {
+    sprint_id?: string;
+    output_dir?: string;
+    from?: string;
+    to?: string;
+  };
+  repos?: Array<{ path: string; label: string }>;
+}
+
+/**
+ * Walk up from startDir looking for .retro.toml. Returns null if not found.
+ */
+export function findRetroConfig(startDir: string = process.cwd()): RetroToml | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, '.retro.toml');
+    if (existsSync(candidate)) {
+      return parse(readFileSync(candidate, 'utf8')) as unknown as RetroToml;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;  // filesystem root
+    dir = parent;
+  }
+  return null;
+}
+```
+
+### Dependency
+
+Add to `package.json` `dependencies`:
+
+```json
+"@iarna/toml": "^2.2.5"
+```
+
+- 19KB, zero transitive deps, TOML 1.0 compliant.
+- Rejected alternative: `.retro.json` — deviates from the org's `daax-cli.toml` precedent referenced in the issue.
+
+### Acceptance
+
+- [ ] `findRetroConfig()` returns `null` when no file exists up to root.
+- [ ] Returns parsed object when `.retro.toml` is in `cwd`.
+- [ ] Returns parsed object when `.retro.toml` is in a parent dir.
+- [ ] Malformed TOML throws a user-readable error (don't swallow the parse exception).
+- [ ] Unit tests use tmp dirs.
+
+---
+
+## Phase 19-C: Analyzer Refactor (`cwd` parameter)
+
+### Files
+
+- `src/analyzers/git.ts`
+- `src/analyzers/github.ts`
+
+### Change
+
+Both analyzers currently call `execSync(...)` with no `cwd` option, implicitly using `process.cwd()`. Add an optional constructor `cwd` parameter with `process.cwd()` default, and pass `{ cwd: this.cwd }` to every `execSync`.
+
+```typescript
+export class GitAnalyzer {
+  private cwd: string;
+  constructor(cwd: string = process.cwd()) {
+    this.cwd = cwd;
+  }
+
+  async isGitRepository(): Promise<boolean> {
+    try {
+      execSync('git rev-parse --git-dir', { stdio: 'pipe', cwd: this.cwd });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  // ...all other execSync calls add { cwd: this.cwd }
+}
+```
+
+Apply the identical pattern to `GitHubAnalyzer` (it calls `gh` which operates on the current dir by default).
+
+### Acceptance
+
+- [ ] `new GitAnalyzer()` (no args) behaves identically to today.
+- [ ] `new GitAnalyzer('/some/other/path')` runs all git operations against that path.
+- [ ] Unit test verifies `cwd` is passed to `execSync` (spy on `child_process.execSync`).
+- [ ] All existing tests pass unchanged.
+
+---
+
+## Phase 19-D: Runner Multi-Repo Loop
+
+### File: `src/runner.ts`
+
+Split current `run()` into `runSingleRepo()` (existing body) and add `runMultiRepo()`.
+
+```typescript
+async run(): Promise<RunResult> {
+  if (this.config.repos && this.config.repos.length > 0) {
+    // Multi-repo mode: ≥1 entry in config or CLI flag
+    return this.runMultiRepo();
+  }
+  return this.runSingleRepo();
+}
+
+private async runMultiRepo(): Promise<RunResult> {
+  const perRepo: PerRepoResult[] = [];
+  for (const repo of this.config.repos!) {
+    const repoPath = resolve(repo.path);
+    const result = await this.runSingleRepoAt(repoPath, repo.label);
+    perRepo.push({ label: repo.label, path: repoPath, ...result });
+  }
+  return this.aggregateMultiRepo(perRepo);
+}
+```
+
+`runSingleRepoAt(repoPath, label)` is a thin wrapper that instantiates analyzers with the given `cwd`.
+
+### Aggregation rules
+
+| Aggregate | Rule |
+|-----------|------|
+| Scores | Weighted by commit count per repo |
+| Findings | Union, deduplicated by `(category, title)` |
+| Action items | Capped at 5 across all repos (constitution `memory/constitution.md:48`) |
+| `data_completeness` | Averaged |
+| `generated_at` | Single timestamp (run start) |
+
+### Acceptance
+
+- [ ] `config.repos = [{path:'.',label:'a'}]` runs multi-repo mode with one repo (useful for labeled single-repo reports).
+- [ ] `config.repos` absent → `runSingleRepo()` path; no behaviour change.
+- [ ] Two-repo run produces two per-repo sections + one summary.
+- [ ] Score aggregation is commit-count-weighted (verify via numeric fixture).
+- [ ] Action items never exceed 5 even if each repo would produce 5.
+
+---
+
+## Phase 19-E: Report Generator
+
+### File: `src/report/generator.ts`
+
+Add:
+
+```typescript
+generateMultiRepoMarkdown(perRepo: PerRepoReportData[], summary: AggregatedSummary): string {
+  let md = this.generateAggregatedSummary(summary);
+  for (const repo of perRepo) {
+    md += `\n---\n\n## Repository: ${repo.label} (\`${repo.path}\`)\n\n`;
+    md += this.generateRepoSection(repo);
+  }
+  return md;
+}
+```
+
+### Acceptance
+
+- [ ] Multi-repo markdown begins with a single aggregated "Executive Summary".
+- [ ] Each repo section has an `## Repository: <label>` header.
+- [ ] Commit / PR / hotspot counts are attributed to their repo.
+- [ ] Single-repo markdown is byte-identical to pre-change output (golden test).
+
+---
+
+## Phase 19-F: CLI
+
+### File: `src/cli.ts`
+
+Add after existing `.option(...)` chain:
+
+```typescript
+.option(
+  '--repo <path>',
+  'Repo path to analyze (repeatable for multi-repo)',
+  (v: string, prev: string[]) => [...(prev || []), v],
+  []
+)
+```
+
+In `.action(options)`:
+
+```typescript
+const toml = findRetroConfig();
+
+// Config-file defaults (lowest precedence)
+if (toml?.retrospective?.sprint_id && !options.sprint) {
+  options.sprint = toml.retrospective.sprint_id;
+}
+if (toml?.retrospective?.output_dir && options.output === 'docs/retrospectives') {
+  options.output = toml.retrospective.output_dir;
+}
+
+// Repos: CLI --repo flags override config
+let repos: RepoConfig[] | undefined;
+if (options.repo?.length > 0) {
+  repos = options.repo.map((p: string, i: number) => ({ path: p, label: `repo-${i + 1}` }));
+} else if (toml?.repos?.length) {
+  repos = toml.repos;
+}
+
+const config: RetroConfig = {
+  // ...existing fields
+  repos,
+};
+```
+
+### Acceptance
+
+- [ ] `--repo ../a` populates `config.repos` with one entry.
+- [ ] `--repo ../a --repo ../b` populates two entries.
+- [ ] With `.retro.toml` present and no `--repo`, repos come from config.
+- [ ] With both present, `--repo` wins.
+- [ ] `--help` shows the new flag.
+
+---
+
+## Integration Testing
+
+### `test/multi-repo.test.ts` (new)
+
+```
+describe('multi-repo mode', () => {
+  it('single-repo default unchanged when no config/flags', async () => { /* ... */ });
+  it('--repo ../a runs against that path', async () => { /* ... */ });
+  it('two --repo flags produce aggregate + per-repo sections', async () => { /* ... */ });
+  it('loads .retro.toml from parent dir', async () => { /* ... */ });
+  it('CLI --repo overrides .retro.toml repos', async () => { /* ... */ });
+  it('aggregate scores are commit-weighted', async () => { /* numeric fixture */ });
+  it('action items capped at 5 across all repos', async () => { /* ... */ });
+});
+```
+
+Use real git operations in a tmpdir (two init'd repos with scripted commits) — matches existing test patterns.
+
+### `.retro.toml` fixture
+
+```toml
+[retrospective]
+sprint_id = "sprint-42"
+output_dir = "docs/retrospectives"
+
+[[repos]]
+path = "."
+label = "frontend"
+
+[[repos]]
+path = "../api"
+label = "api"
+```
+
+---
+
+## Validation Checklist
+
+Before PR:
+
+```bash
+pnpm install            # picks up @iarna/toml
+pnpm run validate       # lint + typecheck + test
+pnpm run build
+# Smoke: single-repo
+node dist/cli.js --from HEAD~10 --output /tmp/retro-single
+# Smoke: multi-repo via CLI
+node dist/cli.js --repo . --repo ../some-other-repo --output /tmp/retro-multi
+# Smoke: via config file
+echo '[[repos]]\npath="."\nlabel="self"' > /tmp/retro-work/.retro.toml
+cd /tmp/retro-work && node <repo>/dist/cli.js
+```
+
+---
+
+## Compatibility & Constitution
+
+- **No breaking changes.** Single-repo default preserved across every matrix row above.
+- Constitution (`memory/constitution.md`) compliance:
+  - Tool remains a pure analytics layer; no new telemetry capture.
+  - Git remains the only hard requirement.
+  - 5-action-item cap enforced at the aggregate level.
+  - Blameless and evidence-driven principles apply equally to per-repo and aggregate sections.
+
+---
+
+## Out of Scope (separate issues if needed)
+
+- GitHub org auto-discovery (`--github-org`).
+- Cross-repo dependency analysis.
+- Monorepo sub-path support (`[[repos]] path = "./packages/api"` is OK if that path is itself a git root, but sub-path of a single repo is not supported).
+- Multi-repo trend tracking (wait for #18 to land; then a separate issue covers per-repo history).
+
+---
+
+## Implementation Order
+
+1. 19-A — types (foundation, no behavior change).
+2. 19-C — analyzer `cwd` refactor (mechanical, backward compat).
+3. 19-B — config discovery (new module + dep).
+4. 19-D — runner multi-repo loop.
+5. 19-E — report generator multi-repo rendering.
+6. 19-F — CLI wiring.
+7. Integration tests + smoke runs.
+
+Each step compiles cleanly and tests pass before moving on.
+
+## References
+
+- `src/types.ts:499–507` — `RetroConfig`
+- `src/analyzers/git.ts:22–33` — `GitAnalyzer` hard-coded `process.cwd()`
+- `src/analyzers/github.ts` — `GitHubAnalyzer` hard-coded `process.cwd()`
+- `src/runner.ts` — runner orchestration
+- `src/cli.ts:23–44` — current CLI option definitions
+- `memory/constitution.md` — project constitution
+- `@iarna/toml` — https://www.npmjs.com/package/@iarna/toml
+- [`docs/updates.md`](../updates.md) — source plan

--- a/docs/plans/skills-best-practices-plan.md
+++ b/docs/plans/skills-best-practices-plan.md
@@ -1,0 +1,205 @@
+# Skills Best-Practices Conformance Plan
+
+**Reference**: [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+**Scope**: Audit + remediate the two skills shipped in this repo.
+**Branch**: `skills-best-practices`
+
+---
+
+## In-Repo Skills
+
+| Path | Current state |
+|------|---------------|
+| `skills/retrospective/SKILL.md` | 65 lines. Shows sub-commands, metrics, output sections. |
+| `skills/claude-best-practices/SKILL.md` | 34 lines. Delegates to `scripts/audit.sh`. |
+| `skills/claude-best-practices/scripts/audit.sh` | 57-line bash script; checks for CLAUDE.md, `.claude/`, hooks.json, settings.json. |
+| `AGENTSKILLS.md` (repo root) | 60-line doc. **Duplicates** retrospective SKILL.md with a different `description` and extra sub-commands. |
+
+---
+
+## Audit Against Best Practices
+
+Checked against the doc's §"Checklist for effective Skills".
+
+### `skills/retrospective/SKILL.md`
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Description is specific + includes key terms | ⚠️ | "Evidence-based sprint retrospectives with objective metrics from git, GitHub, and decision logs." Good subject, missing explicit "when to use". |
+| Description includes when-to-use trigger | ❌ | Add: "Use when the user asks to run a sprint retrospective, analyze commit/PR patterns over a period, or review decision-log quality." |
+| Third-person descriptions | ✅ | Already third-person. |
+| Body under 500 lines | ✅ | 65 lines. |
+| Reference files one level deep | ✅ | No references currently. |
+| No time-sensitive info | ✅ | |
+| Consistent terminology | ⚠️ | "retrospective" is consistent; "sub-commands" vs listing them as flags/subcommands inconsistently. |
+| Examples concrete | ⚠️ | Sub-command examples use `npx agentic-retrospective …`; `setup` shows raw `mkdir` instead of a real command. |
+| No Windows paths | ✅ | |
+| Valid name (lowercase, hyphens, no reserved words) | ✅ | `retrospective`. Could be gerund form (`running-retrospectives`) but not required. |
+| Single `name` + `description` in frontmatter | ✅ | |
+| `invocation` field | ⚠️ | Uses `invocation: /daax:retrospective` — non-standard frontmatter key; confirm whether Claude Code supports it or drop it. |
+
+### `skills/claude-best-practices/SKILL.md`
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Description specific + when-to-use | ❌ | "Audit your Claude Code configuration against official Anthropic best practices." Second person ("your"). Missing when-to-use trigger. |
+| Third person | ❌ | "your" → rewrite. |
+| Body concise | ✅ | 34 lines. |
+| Execution intent clear | ⚠️ | Says `Run: agentic-retrospective audit` but the CLI has no `audit` subcommand in `src/cli.ts`. The actual script is `skills/claude-best-practices/scripts/audit.sh`. **Broken.** |
+| Scripts solve, don't punt | ⚠️ | `audit.sh` only checks file existence. Doesn't enforce the actual best-practices listed in the skill body (CLAUDE.md size > 500, skill versioning). |
+| No "voodoo constants" | N/A | |
+| Name is descriptive, not reserved | ✅ | `claude-best-practices`. |
+| Imperative "Execute immediately" is consistent with low-freedom task | ✅ | Appropriate for an audit. |
+
+### Duplication: `AGENTSKILLS.md` vs `skills/retrospective/SKILL.md`
+
+`AGENTSKILLS.md` at the repo root is effectively a second skill manifest with a different `description` field. This creates two sources of truth. Best-practices doc is explicit: "Each Skill has exactly one description field. The description is critical for skill selection."
+
+**Resolution**: Pick one location. If `AGENTSKILLS.md` is required by a tool we use, make it regenerate from `skills/retrospective/SKILL.md` or import-by-reference. Otherwise, delete it and rely on `skills/retrospective/SKILL.md`.
+
+---
+
+## Remediation
+
+### Change 1 — Rewrite `skills/retrospective/SKILL.md` description
+
+```yaml
+---
+name: retrospective
+description: Generates evidence-based sprint retrospectives from git history, GitHub PRs, and decision logs. Use when the user asks to run a retrospective, review a sprint, analyze commit or PR patterns over a period, or audit decision-log quality.
+---
+```
+
+### Change 2 — Rewrite `skills/claude-best-practices/SKILL.md`
+
+Fix third-person voice, correct the execution command, add when-to-use.
+
+```markdown
+---
+name: claude-best-practices
+description: Audits a Claude Code project's CLAUDE.md, hooks, settings, and skills against Anthropic's published best practices. Use when the user asks to audit their Claude Code setup, validate CLAUDE.md, or check skill compliance before a retrospective.
+---
+
+# Claude Best Practices Audit
+
+Execute immediately. Do not ask for confirmation.
+
+Run: `bash skills/claude-best-practices/scripts/audit.sh`
+
+## What It Checks
+
+- Presence and structure of `CLAUDE.md`
+- CLAUDE.md size (warn above 500 lines, per Anthropic skill guidance)
+- `.claude/` layout, hooks.json, settings.json
+- Skill frontmatter (`name`, `description`) across `skills/*/SKILL.md`
+- Description quality: third person, includes when-to-use, non-empty
+
+## Output
+
+- **Errors**: blocking issues — e.g., missing CLAUDE.md
+- **Warnings**: recommended improvements — e.g., SKILL.md body over 500 lines
+- **Info**: informational signals — e.g., detected hook configurations
+
+## When To Use
+
+- Before conducting a retrospective
+- After major CLAUDE.md changes
+- When onboarding a new project
+- Periodically, to catch drift
+```
+
+### Change 3 — Upgrade `scripts/audit.sh` to enforce best-practices
+
+Add checks that actually match the claims in the SKILL.md body:
+
+```bash
+# New checks to add:
+# 1. CLAUDE.md line count > 500 → warning
+# 2. For each skills/*/SKILL.md:
+#    - frontmatter parses (has ---)
+#    - has `name:` field, lowercase + hyphens, ≤ 64 chars
+#    - has `description:` field, non-empty, ≤ 1024 chars
+#    - description does not contain "I " or "you" (third-person check)
+#    - SKILL.md body line count ≤ 500 (excluding frontmatter)
+# 3. Warn if AGENTSKILLS.md exists alongside skills/*/SKILL.md (duplication risk)
+```
+
+Wire the script so it exits non-zero on errors and zero on warnings/info (preserve current behaviour).
+
+### Change 4 — Resolve `AGENTSKILLS.md` duplication
+
+Two options — pick one based on whether Claude Code requires `AGENTSKILLS.md`:
+
+1. **Delete** `AGENTSKILLS.md`; update any reference in `README.md` / `plugin.json` to point at `skills/retrospective/SKILL.md`.
+2. **Regenerate** `AGENTSKILLS.md` from `skills/retrospective/SKILL.md` via a small script; add a CI check that they stay in sync.
+
+The agent running this branch should inspect `plugin.json` and `README.md` to determine which option is safe, and prefer **delete** unless tooling requires it.
+
+### Change 5 — Drop the `invocation:` frontmatter key if unsupported
+
+Anthropic's schema for SKILL.md defines only `name` and `description`. `invocation: /daax:retrospective` appears to be a Claude Code convention. Verify in the Claude Code docs; if it's not part of the supported schema, remove it to avoid parser warnings.
+
+### Change 6 — Add missing reference files if any section exceeds 500 lines
+
+Not currently a problem (both are under 100 lines) but document the pattern so future contributors know when to split.
+
+Add to the audit script a line-count check on each SKILL.md body.
+
+### Change 7 — Evaluation harness (stretch)
+
+Per best-practices §"Build evaluations first", add three evaluation scenarios under `skills/retrospective/evaluations/`:
+
+```json
+{"skills": ["retrospective"], "query": "Run a retrospective for the last 2 weeks", "expected_behavior": ["Invokes agentic-retrospective CLI", "Produces docs/retrospectives/YYYY-MM-DD/retrospective.md"]}
+{"skills": ["retrospective"], "query": "Show me which PRs got superseded last sprint", "expected_behavior": ["Uses GitHub analyzer", "Reports supersession rate"]}
+{"skills": ["retrospective"], "query": "How many decisions were agent-initiated this sprint?", "expected_behavior": ["Reads decision logs", "Reports agent vs human actor counts"]}
+```
+
+These are documentation only until an evaluation runner exists; they make skill intent explicit.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `skills/retrospective/SKILL.md` description rewritten to include when-to-use trigger; passes third-person check.
+- [ ] `skills/claude-best-practices/SKILL.md` rewritten to third person, fixed execution command, includes when-to-use.
+- [ ] `scripts/audit.sh` parses every `skills/*/SKILL.md` frontmatter and reports:
+  - missing/invalid `name`
+  - missing `description`
+  - first/second-person pronouns in `description`
+  - body line count > 500
+- [ ] `scripts/audit.sh` exits 0 for current repo after Changes 1–2 land.
+- [ ] `AGENTSKILLS.md` decision is made and applied (delete or regenerate).
+- [ ] `invocation:` frontmatter is verified and either kept or removed consistently across skills.
+- [ ] Three evaluation stubs added under `skills/retrospective/evaluations/` (or documented why skipped).
+
+---
+
+## Validation
+
+```bash
+bash skills/claude-best-practices/scripts/audit.sh .
+# Expected: Errors: 0
+
+# Re-lint the repo
+pnpm run validate
+```
+
+Manual smoke: load the skills via Claude Code (`/retrospective`) and confirm discoverability still works.
+
+---
+
+## Out of Scope
+
+- Rewriting the retrospective skill into progressive-disclosure multi-file layout. Current 65-line body is well under the 500-line threshold.
+- Building a full evaluation runner. Three scenarios documented is enough for this pass.
+- Changes to `plugin.json` beyond what's needed to resolve the `AGENTSKILLS.md` decision.
+
+## References
+
+- [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+- `skills/retrospective/SKILL.md`
+- `skills/claude-best-practices/SKILL.md`
+- `skills/claude-best-practices/scripts/audit.sh`
+- `AGENTSKILLS.md` (duplication source)
+- `plugin.json`

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,677 @@
+# Update Plan: agentic-retrospective
+
+**Date**: 2026-04-10  
+**Scope**: Best-practices audit + fix plans for daax-dev/agentic-retrospective#18 and daax-dev/agentic-retrospective#19
+
+---
+
+## Executive Summary
+
+This document covers three areas:
+
+1. A best-practices audit of the current tool, including issues not yet filed as GitHub issues.
+2. Fix plan for [#18 — Feature suggestions from a real-world automated integration](https://github.com/daax-dev/agentic-retrospective/issues/18).
+3. Fix plan for [#19 — Multi-repo support for team retrospectives](https://github.com/daax-dev/agentic-retrospective/issues/19).
+
+All findings are ranked by impact. All implementation decisions are logged below in JSONL format. References are cited inline and consolidated at the end.
+
+---
+
+## Best Practices Audit
+
+### Gaps
+
+#### BP-1: No tool-level configuration file
+
+**Severity**: High
+
+The tool has no persistent configuration file. `RetroConfig` (`src/types.ts:499–507`) is populated entirely from CLI flags passed on every invocation. There is no config file discovery, no defaults persistence, and no way to encode per-workspace settings such as sprint_id patterns, output directories, or multiple repo paths.
+
+The `.github/ISSUE_TEMPLATE/config.yml` is an issue template configuration, not a tool config. The tool itself has no equivalent artifact.
+
+**Best practice**: Any CLI tool with more than three recurring configuration parameters should support a config file discovered from the working directory. TOML, JSON, and YAML are all common choices; the issue #19 proposal uses `.retro.toml` to match the `daax-cli.toml` pattern already established in the org.
+
+**Fix**: Addressed by issue #19 (see Phase 19-B).
+
+---
+
+#### BP-2: Hard-coded `process.cwd()` in analyzers
+
+**Severity**: High
+
+Both `GitAnalyzer` (`src/analyzers/git.ts:26–32`, `isGitRepository()`) and `GitHubAnalyzer` (`src/analyzers/github.ts`) execute `execSync` calls without a `cwd` option, implicitly using `process.cwd()`. This global state dependency means:
+
+- Analyzers cannot be pointed at a different repository without forking a subprocess.
+- Multi-repo analysis is architecturally impossible without process-level workarounds.
+- Unit tests must manipulate `process.cwd()` or use temp dirs to test different repos.
+
+**Best practice**: Analyzers should accept explicit paths rather than rely on implicit global state. Default to `process.cwd()` for backward compatibility.
+
+**Fix**: Addressed by issue #19 (see Phase 19-C).
+
+---
+
+#### BP-3: Silent `evidence_refs` validation failure
+
+**Severity**: Medium
+
+`buildEvidenceMap()` in `src/runner.ts:657–665` only links refs matching the regex `/commit:(\w+)/`. Decision records with `evidence_refs` using any other format (e.g., raw issue IDs like `"claw-abc"`, `"ISSUE-123"`) are silently accepted by schema validation but produce orphaned evidence — their decisions never link to any commit.
+
+The failure mode is invisible. Users see orphaned decisions in the evidence map but receive no diagnostic message explaining why.
+
+**Best practice**: When input data matches a schema type but fails a format constraint, emit a warning at the point of first use. Silent data loss is a reliability anti-pattern in any analytics tool.
+
+**Fix**: Addressed by issue #18, item 2 (see Fix 18-B).
+
+---
+
+#### BP-4: No cross-sprint trend tracking
+
+**Severity**: Medium
+
+Each run is fully standalone. The tool produces rich per-sprint scores across six dimensions (`src/types.ts:115–122`) but persists nothing between runs. Users cannot detect whether scores are improving, declining, or stable over time without manual record-keeping.
+
+**Best practice**: Any analytics tool intended for recurring use (sprint-over-sprint) should maintain a lightweight history file enabling trend detection.
+
+**Fix**: Addressed by issue #18, item 1 (see Fix 18-A).
+
+---
+
+#### BP-5: No PR-based CI workflow
+
+**Severity**: Medium
+
+`.github/workflows/publish.yml` runs only on push to `main`. There is no workflow that validates pull requests before merge. The existing `prepublishOnly` script runs `pnpm run build` and provides a partial safety net, but broken lint or test failures can reach `main` undetected.
+
+**Best practice**: Every PR should be gated by CI running the full `pnpm run validate` (`lint + typecheck + test`) suite.
+
+**Fix**: Add `.github/workflows/ci.yml` (see Standalone CI Improvement).
+
+---
+
+#### BP-6: Publish workflow triggers on any `package.json` change
+
+**Severity**: Low
+
+The publish trigger (`paths: ['package.json']`) fires on any `package.json` mutation — keyword edits, author changes, script additions — not just version bumps. The version-check step (`.github/workflows/publish.yml:44–54`) prevents duplicate publishes but the workflow still executes unnecessarily.
+
+**Best practice**: Use `workflow_dispatch` with a version parameter, a tag-based trigger (`on: push: tags: ['v*']`), or restrict to the `version` field specifically.
+
+---
+
+#### BP-7: Missing adapter documentation for `evidence_refs` format
+
+**Severity**: Medium
+
+`docs/fixing-telemetry-gaps.md` documents decision logging thoroughly but does not explain the `commit:<hash>` requirement for `evidence_refs`. Users integrating external issue trackers (Linear, Jira) encounter the silent orphaning described in BP-3 with no documentation to guide them.
+
+**Fix**: Addressed by issue #18, item 3 (see Fix 18-C).
+
+---
+
+#### BP-8: `RetroConfig` has no repo identity concept
+
+**Severity**: High (blocks #19)
+
+`RetroConfig` (`src/types.ts:499–507`) has no `repos` field, no `path`, and no `label`. It assumes single-repo, single-`process.cwd()` operation. Adding multi-repo support requires extending this type without breaking existing callers.
+
+**Fix**: Addressed by issue #19 (see Phase 19-A).
+
+---
+
+#### BP-9: `analyzeSprit` typo in `runner.ts`
+
+**Severity**: Low
+
+`src/runner.ts:687` contains `analyzeSprit` (missing 'n'). This is a private method so it does not affect the public API, but it is a code quality issue.
+
+**Fix**: Rename to `analyzeSprint` in the same PR as any other `runner.ts` changes.
+
+---
+
+### What Is Working Well
+
+| Practice | Evidence |
+|----------|----------|
+| Graceful degradation | All sources optional except git; missing sources reduce confidence, not output. `memory/constitution.md:52–57` |
+| Decision record validation | `DecisionAnalyzer.isValidRecord()` screens malformed records before analysis |
+| Evidence linking architecture | `EvidenceMap` type (`src/types.ts:405–422`) provides a solid foundation for traceability |
+| Blameless design | Constitutionally enforced (`memory/constitution.md:28–35`) |
+| SLSA provenance | `npm publish --provenance` used in `.github/workflows/publish.yml:58` |
+| TypeScript strict mode | Enforced via `tsconfig.json`; ESLint configured in `.eslintrc.json` |
+| Publish version guard | Version check step prevents re-publishing the same version |
+| Schema versioning | All JSON outputs include `metadata.schema_version` |
+
+---
+
+## Fix Plan: Issue #18
+
+**Issue**: [Feature suggestions from a real-world automated integration](https://github.com/daax-dev/agentic-retrospective/issues/18)  
+**Reporter**: DMokong (collaborator)  
+**Filed**: 2026-03-22  
+**Items**: Three distinct, independently releasable fixes.
+
+---
+
+### Fix 18-A: Multi-Sprint Trend Tracking
+
+**Goal**: After each successful run, append a score snapshot to a persistent history file, enabling trend detection across sprints.
+
+**Files to change**:
+
+| File | Change |
+|------|--------|
+| `src/types.ts` | Add `SprintHistoryEntry` interface |
+| `src/runner.ts` | Add `appendToHistory()`, call it from `writeOutputs()` |
+
+**New type** (`src/types.ts`, after `RetroConfig`):
+
+```typescript
+export interface SprintHistoryEntry {
+  sprint_id: string;
+  date: string;               // ISO 8601
+  scores: Scores;
+  data_completeness: number;  // 0–100 percentage
+}
+```
+
+**Implementation** (`src/runner.ts`, inside `writeOutputs()`):
+
+```typescript
+// appendFileSync: already in the runner.ts:8 fs destructure: { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync }
+// → add appendFileSync to that destructure
+// resolve: already imported via 'path' at runner.ts:9 (join is imported; add resolve)
+
+private appendToHistory(report: RetroReport): void {
+  const historyPath = resolve(this.config.outputDir, '../.retro-history.jsonl');
+  const entry: SprintHistoryEntry = {
+    sprint_id: report.sprint_id,
+    date: report.generated_at,
+    scores: report.scores,
+    data_completeness: report.data_completeness.percentage,
+  };
+  appendFileSync(historyPath, JSON.stringify(entry) + '\n', 'utf8');
+}
+```
+
+Call site in `writeOutputs()` (`src/runner.ts:1086`): add `this.appendToHistory(report);` after the markdown write, before `return outputPath`.
+
+**History file location**: `resolve(outputDir, '../.retro-history.jsonl')` — one level above the sprint-specific output dirs, spanning all sprints. Using `resolve()` is necessary because `outputDir` may be a relative path (default: `docs/retrospectives`); `join('../..')` on a relative path produces an incorrect result if the process changes directory.
+
+**Compatibility**: Fully additive. No existing behavior changes. History file is created on first run.
+
+**Testing**: Unit test that calls `writeOutputs()` twice with different sprint IDs and verifies `.retro-history.jsonl` contains exactly two lines with distinct `sprint_id` values.
+
+---
+
+### Fix 18-B: Evidence Refs Format Validation Warning
+
+**Goal**: When `evidence_refs` contain entries with no recognized prefix, emit a warning to stderr (to avoid corrupting `--json` stdout) and record a `TelemetryGap`.
+
+**Root cause** (`src/runner.ts:657–665`): The `buildEvidenceMap()` method only links refs matching `/commit:(\w+)/`. Two silent failure modes exist:
+1. Any prefix other than `commit:` produces no link and no warning.
+2. The regex `\w+` captures the hash, but the lookup `map.commits[match[1]]` requires an exact match against the full 40-character commit hash indexed at line 638. Short hashes (e.g., `commit:a1b2c3d`) never match even when the commit exists in the period, silently producing an orphan.
+
+Non-matching refs produce no diagnostic output in either case.
+
+**Known valid prefixes** (from existing `runner.ts` usage):
+
+| Prefix | Links to |
+|--------|----------|
+| `commit:<hash>` | Git commit |
+| `pr:<number>` | GitHub pull request |
+| `decision:<id>` | Another decision record |
+| `file:<path>` | Source file |
+| `inferred:<reason>` | No artifact — marks inferred evidence |
+
+**Implementation** (`src/runner.ts`, at the top of `buildEvidenceMap()`):
+
+```typescript
+private buildEvidenceMap(data: CollectedData): EvidenceMap {
+  const VALID_PREFIXES = ['commit:', 'decision:', 'pr:', 'file:', 'inferred:'];
+  const unrecognizedRefs: string[] = [];
+
+  // Build a short→full hash index so commit:a1b2c3d resolves correctly
+  const shortHashIndex = new Map<string, string>();
+  if (data.git?.commits) {
+    for (const c of data.git.commits) {
+      // Index by all prefix lengths 7–12 chars for flexible matching
+      for (let len = 7; len <= Math.min(12, c.hash.length); len++) {
+        shortHashIndex.set(c.hash.slice(0, len), c.hash);
+      }
+    }
+  }
+
+  if (data.decisions?.records) {
+    for (const decision of data.decisions.records) {
+      for (const ref of (decision.evidence_refs || [])) {
+        if (!VALID_PREFIXES.some(p => ref.startsWith(p))) {
+          unrecognizedRefs.push(
+            `decision ${decision.id || '?'}: "${ref}"`
+          );
+        }
+      }
+    }
+  }
+
+  if (unrecognizedRefs.length > 0) {
+    process.stderr.write(
+      `[WARN] ${unrecognizedRefs.length} evidence_ref(s) have unrecognized format and will be orphaned:\n`
+    );
+    unrecognizedRefs.slice(0, 5).forEach(r =>
+      process.stderr.write(`  - ${r}\n`)
+    );
+    process.stderr.write(
+      '  Valid formats: commit:<hash>, pr:<number>, decision:<id>, file:<path>\n'
+    );
+    this.addTelemetryGap({
+      gap_type: 'unrecognized_evidence_refs',
+      severity: 'medium',
+      impact: `${unrecognizedRefs.length} evidence_refs have unrecognized format and will not link to any artifact`,
+      recommendation: 'Use prefixed formats: commit:<hash>, pr:<number>, decision:<id>, file:<path>. See docs/fixing-telemetry-gaps.md.',
+    });
+  }
+
+  // ... existing map initialization continues
+  // NOTE: When resolving commit: refs below, replace:
+  //   map.commits[match[1]]
+  // with:
+  //   map.commits[shortHashIndex.get(match[1]) ?? match[1]]
+  // to support both short (7-char) and full 40-char hashes.
+```
+
+**Compatibility**: Warning-only. No data is removed or altered. Existing users with valid refs see no change.
+
+**Testing**: Unit test with a decision record containing `evidence_refs: ["claw-abc", "ISSUE-123"]`. Verify stderr receives a warning, a `TelemetryGap` is added, and the evidence map's `orphans.decisions_without_implementation` contains the decision.
+
+---
+
+### Fix 18-C: Adapter Documentation
+
+**Goal**: Add a section to `docs/fixing-telemetry-gaps.md` documenting the `commit:<hash>` format requirement and showing how to correlate issue tracker records with git commits.
+
+**File to change**: `docs/fixing-telemetry-gaps.md` — append a new section.
+
+**Content to add**:
+
+```markdown
+## Linking Issue Tracker Records to Git Commits (evidence_refs)
+
+The `evidence_refs` field links a decision to specific artifacts. Every ref must use a recognized prefix:
+
+| Prefix | Format | Links to |
+|--------|--------|----------|
+| `commit:` | `commit:<full-or-short-hash>` | A git commit |
+| `pr:` | `pr:<number>` | A GitHub pull request |
+| `decision:` | `decision:<id>` | Another decision record |
+| `file:` | `file:<relative-path>` | A source file |
+| `inferred:` | `inferred:<reason>` | Marks inferred evidence (no artifact) |
+
+### Correlating an Issue Tracker Record
+
+To link a decision to the commit that resolves a Linear/Jira issue:
+
+1. Find the git commit: `git log --oneline --grep="ISSUE-123"`
+2. Use the commit hash in `evidence_refs`:
+
+\`\`\`json
+{
+  "ts": "2026-03-15T10:30:00Z",
+  "decision": "Adopted optimistic locking for inventory updates",
+  "rationale": "Reduces contention under concurrent write load",
+  "evidence_refs": ["commit:a1b2c3d", "pr:47"]
+}
+\`\`\`
+
+**Common mistake**: Using raw issue IDs (`"ISSUE-123"`, `"claw-abc"`) directly.
+These have no recognized prefix and are silently orphaned. Always resolve
+to a `commit:` or `pr:` reference before logging.
+```
+
+---
+
+## Fix Plan: Issue #19
+
+**Issue**: [Multi-repo support for team retrospectives](https://github.com/daax-dev/agentic-retrospective/issues/19)  
+**Reporter**: rileyedwards77 (collaborator)  
+**Filed**: 2026-03-22  
+**Scope**: Larger feature across type system, config loading, analyzers, runner, report generator, and CLI. Zero breaking changes required.
+
+---
+
+### Phase 19-A: Type System Updates
+
+**File**: `src/types.ts`
+
+Add `RepoConfig` and extend `RetroConfig`:
+
+```typescript
+// New type — add before RetroConfig
+export interface RepoConfig {
+  path: string;    // Absolute or relative path to repo root
+  label: string;  // Human-readable label used in reports
+}
+
+// Update RetroConfig — add one optional field
+export interface RetroConfig {
+  fromRef: string;
+  toRef: string;
+  sprintId: string;
+  decisionsPath: string;
+  agentLogsPath: string;
+  ciPath?: string;
+  outputDir: string;
+  repos?: RepoConfig[];  // NEW: empty / absent = single-repo (cwd)
+}
+```
+
+Add history type (see also Fix 18-A):
+
+```typescript
+export interface SprintHistoryEntry {
+  sprint_id: string;
+  date: string;
+  scores: Scores;
+  data_completeness: number;
+}
+```
+
+---
+
+### Phase 19-B: `.retro.toml` Config File Discovery
+
+**New file**: `src/config.ts`
+
+```typescript
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { parse } from '@iarna/toml';  // new dependency
+
+export interface RetroToml {
+  retrospective?: {
+    sprint_id?: string;
+    output_dir?: string;
+    from?: string;
+    to?: string;
+  };
+  repos?: Array<{ path: string; label: string }>;
+}
+
+/**
+ * Walk up from startDir looking for .retro.toml.
+ * Returns null if not found.
+ */
+export function findRetroConfig(startDir: string = process.cwd()): RetroToml | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, '.retro.toml');
+    if (existsSync(candidate)) {
+      return parse(readFileSync(candidate, 'utf8')) as RetroToml;
+    }
+    const parent = dirname(dir);
+    // dirname('/') === '/' and dirname('C:\\') === 'C:\\' — works on macOS, Linux, and Windows
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+// Security note: the TOML file is read from the local filesystem only.
+// Symlink traversal is not a concern for config discovery in a trusted workspace.
+```
+
+**New dependency**: `@iarna/toml` — 19KB, zero transitive dependencies, full TOML 1.0 compliance. Add to `dependencies` in `package.json`.
+
+**Alternative considered**: `.retro.json` (avoids new dependency). Rejected because the proposal explicitly uses `.retro.toml` to match the org's `daax-cli.toml` precedent.
+
+---
+
+### Phase 19-C: Analyzer Refactoring
+
+**Files**: `src/analyzers/git.ts`, `src/analyzers/github.ts`
+
+Add `cwd` constructor parameter with `process.cwd()` default:
+
+```typescript
+// src/analyzers/git.ts
+export class GitAnalyzer {
+  private cwd: string;
+
+  constructor(cwd: string = process.cwd()) {
+    this.cwd = cwd;
+  }
+
+  async isGitRepository(): Promise<boolean> {
+    try {
+      execSync('git rev-parse --git-dir', { stdio: 'pipe', cwd: this.cwd });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async analyze(fromRef: string, toRef: string = 'HEAD'): Promise<GitAnalysisResult> {
+    // All execSync calls: add cwd: this.cwd to options
+  }
+}
+```
+
+Apply the same pattern to `GitHubAnalyzer`. All existing call sites pass no `cwd` argument and continue to work unchanged.
+
+---
+
+### Phase 19-D: Runner Multi-Repo Loop
+
+**File**: `src/runner.ts`
+
+Refactor `run()` to dispatch based on whether `repos` is populated:
+
+```typescript
+async run(): Promise<RunResult> {
+  if (this.config.repos && this.config.repos.length > 1) {
+    return this.runMultiRepo();
+  }
+  return this.runSingleRepo();
+}
+
+// Rename existing run() body to runSingleRepo():
+private async runSingleRepo(): Promise<RunResult> {
+  // ... existing phases 0–5, unchanged
+}
+
+private async runMultiRepo(): Promise<RunResult> {
+  const perRepo: PerRepoResult[] = [];
+  for (const repo of this.config.repos!) {
+    const repoPath = resolve(repo.path);
+    const result = await this.runSingleRepoAt(repoPath);
+    perRepo.push({ label: repo.label, path: repoPath, ...result });
+  }
+  return this.aggregateMultiRepo(perRepo);
+}
+```
+
+`runSingleRepoAt(repoPath)` is a thin wrapper that temporarily overrides the `cwd` passed to all analyzers for that repo.
+
+---
+
+### Phase 19-E: Report Generator Updates
+
+**File**: `src/report/generator.ts`
+
+Add multi-repo section rendering:
+
+```typescript
+generateMultiRepoMarkdown(perRepo: PerRepoReportData[], summary: AggregatedSummary): string {
+  let md = this.generateAggregatedSummary(summary);
+  for (const repo of perRepo) {
+    md += `\n---\n\n## Repository: ${repo.label} (\`${repo.path}\`)\n\n`;
+    md += this.generateRepoSection(repo);
+  }
+  return md;
+}
+```
+
+The unified executive summary aggregates scores (weighted by commit count), findings (deduplicated), and action items (max 5 across all repos — enforced by the constitution, `memory/constitution.md:48`).
+
+**Constitution compliance**: Multi-repo support does not violate any constitutional constraint. The tool remains a pure analytics layer; it reads from multiple repos but still does not capture telemetry, install hooks, or write to `.logs/` (`memory/constitution.md:11–14`). The blameless and evidence-driven principles apply equally to per-repo and aggregate sections.
+
+---
+
+### Phase 19-F: CLI Updates
+
+**File**: `src/cli.ts`
+
+Add `--repo` flag and config file loading:
+
+```typescript
+program
+  .option(
+    '--repo <path>',
+    'Repo path to analyze (repeatable for multi-repo)',
+    (v: string, prev: string[]) => [...(prev || []), v],
+    []
+  )
+
+// In .action():
+const toml = findRetroConfig();
+
+// Apply config file defaults, then override with CLI flags
+if (toml?.repos?.length) {
+  config.repos = toml.repos;
+}
+if (options.repo?.length > 0) {
+  config.repos = options.repo.map((p: string, i: number) => ({
+    path: p,
+    label: `repo-${i + 1}`,
+  }));
+}
+```
+
+---
+
+### Compatibility Matrix
+
+| Scenario | Behavior |
+|----------|----------|
+| No `.retro.toml`, no `--repo` | Current behavior — analyzes `cwd`. Zero breaking changes. |
+| `.retro.toml` present, no `[[repos]]` | Sprint metadata from config, single-repo mode. |
+| `.retro.toml` with `[[repos]]` | Multi-repo mode from config file. |
+| `--repo ../other` | Analyzes `../other` instead of `cwd`. |
+| `--repo ./a --repo ./b` | Multi-repo mode, per-repo sections + unified summary. |
+| `--repo` flags + `.retro.toml` | CLI flags override config file repos. |
+
+---
+
+## Standalone CI Improvement
+
+**Finding**: No CI workflow validates pull requests before merge (BP-5).
+
+**New file**: `.github/workflows/ci.yml`
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run validate
+```
+
+This runs `lint + typecheck + test` on every PR and every non-doc push to `main`.
+
+---
+
+## Implementation Order & Prioritization
+
+Effort key: XS < 1h, S < 4h, M < 1d, L < 3d.
+
+| Priority | Fix | Effort | Risk | Required Tests | Rationale |
+|----------|-----|--------|------|----------------|-----------|
+| 1 | 18-B (evidence_refs warning) | S | None | Unit: orphaned refs produce stderr + TelemetryGap | Warning-only, no behavior change, immediate user value |
+| 2 | 18-C (adapter docs) | S | None | Manual review | Documentation only, zero code risk |
+| 3 | CI workflow (BP-5) | S | None | Validated by CI itself on first PR | Improves future change safety |
+| 4 | 18-A (trend tracking) | M | Low | Unit: two runs → two JSONL lines in history | Additive only, new file |
+| 5 | 19-A + 19-C (types + analyzer cwd) | M | Low | Unit: GitAnalyzer with explicit cwd | Foundation for multi-repo, backward compatible |
+| 6 | 19-B (config discovery) | M | Low | Unit: walk-up finds .retro.toml; missing → null | Requires new dependency decision |
+| 7 | 19-D + 19-E + 19-F (runner + report + CLI) | L | Medium | Integration: two-repo run produces per-repo sections | Depends on 19-A, 19-B, 19-C |
+| 8 | BP-9 (typo fix) | XS | None | Existing tests pass | Cleanup |
+| 9 | BP-6 (publish trigger) | S | Low | CI run confirms no spurious publishes | Operational hygiene |
+
+---
+
+## Decision Log
+
+```jsonl
+{"ts":"2026-04-10T00:00:00Z","decision":"Scope #18 into three discrete fixes (18-A trend, 18-B validation, 18-C docs)","rationale":"Each fix is independently releasable and testable; avoids a single large PR blocking user value","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:01Z","decision":"Use appendFileSync for history file writes rather than read-parse-write","rationale":"JSONL is append-only by design; avoids loading and re-serializing the entire history on every run","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:02Z","decision":"Emit evidence_refs warnings to stderr, not stdout","rationale":"The --json flag routes stdout to consumers; interleaving warnings would corrupt machine-readable output","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:03Z","decision":"Use @iarna/toml for TOML parsing rather than hand-rolling","rationale":"Correctness and TOML 1.0 spec compliance; @iarna/toml has zero transitive dependencies and is 19KB","actor":"agent","category":"deps","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:04Z","decision":"Default GitAnalyzer and GitHubAnalyzer cwd to process.cwd()","rationale":"Preserves full backward compatibility; all existing call sites pass no argument and continue working","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:05Z","decision":"Place .retro-history.jsonl one level above outputDir","rationale":"outputDir contains sprint-specific subdirectories; history spans all sprints and must sit outside any single sprint dir","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:06Z","decision":"Add CI workflow as a separate file from publish.yml rather than extending publish.yml","rationale":"Publish and CI have different triggers and permissions; combining them creates unnecessary coupling","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:07Z","decision":"Extend fixing-telemetry-gaps.md for adapter docs rather than creating a new file","rationale":"Users are already directed to that doc for telemetry issues; co-location reduces discovery friction","actor":"agent","category":"process","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:08Z","decision":"Reject .retro.json in favor of .retro.toml for config file format","rationale":"Issue #19 explicitly proposes TOML to match org-wide daax-cli.toml precedent; JSON would deviate from stated design intent","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+{"ts":"2026-04-10T00:00:09Z","decision":"Aggregate multi-repo scores weighted by commit count, not simple average","rationale":"A repo with 300 commits should carry more weight in the unified score than a repo with 10; simple averaging is misleading","actor":"agent","category":"architecture","decision_type":"two_way_door","evidence_refs":["commit:HEAD"]}
+```
+
+---
+
+## What This Plan Does Not Change
+
+The following behaviors are explicitly preserved in every fix above, in compliance with `memory/constitution.md`:
+
+| Constitutional Principle | How This Plan Honors It |
+|--------------------------|-------------------------|
+| Pure analytics layer — reads data, does not capture it | No fix writes to `.logs/`; history file is an output artifact, not telemetry |
+| Git history is the only hard requirement | Multi-repo mode still requires git at each repo path; graceful degradation is unchanged |
+| Maximum 5 action items per report | The aggregate multi-repo report enforces this cap across all repos |
+| Every claim links to evidence or is marked "inferred" | Evidence map format is unchanged; per-repo sections use the same traceability model |
+| Blameless — evaluate systems, not people | No new metrics that attribute findings to individuals |
+| No fabricated rationales | Orphaned evidence is surfaced (18-B) rather than silently dropped |
+
+---
+
+## References
+
+1. daax-dev/agentic-retrospective#18 — Feature suggestions from a real-world automated integration (DMokong, 2026-03-22)
+2. daax-dev/agentic-retrospective#19 — Multi-repo support for team retrospectives (rileyedwards77, 2026-03-22)
+3. `src/types.ts:499–507` — `RetroConfig` type definition
+4. `src/types.ts:115–122` — `Scores` type definition
+5. `src/types.ts:405–422` — `EvidenceMap` type definition
+6. `src/runner.ts:625–685` — `buildEvidenceMap()` implementation (evidence orphaning root cause)
+7. `src/runner.ts:687` — `analyzeSprit` typo (private method, non-breaking)
+8. `src/runner.ts:1055–1089` — `writeOutputs()` (history append call site)
+9. `src/analyzers/git.ts:22–33` — `GitAnalyzer` with hard-coded `process.cwd()`
+10. `src/analyzers/github.ts` — `GitHubAnalyzer` with hard-coded `process.cwd()`
+11. `src/cli.ts:23–44` — Current CLI option definitions (no `--repo` flag)
+12. `memory/constitution.md` — Project constitution, graceful degradation and blameless principles
+13. `.github/workflows/publish.yml` — Current CI/CD publish workflow (no PR gate)
+14. `.github/ISSUE_TEMPLATE/config.yml` — Issue template config (not a tool config)
+15. `docs/fixing-telemetry-gaps.md` — Telemetry gap remediation guide (missing `evidence_refs` section)
+16. `examples/decisions.jsonl` — Example decision log
+17. `@iarna/toml` npm package — TOML 1.0 parser, zero transitive deps (https://www.npmjs.com/package/@iarna/toml)
+18. TOML specification v1.0.0 — https://toml.io/en/v1.0.0
+19. SLSA provenance specification — https://slsa.dev/provenance/v1
+20. `src/runner.ts:8` — fs destructure (`existsSync`, `mkdirSync`, `readdirSync`, `readFileSync`, `writeFileSync`); `appendFileSync` must be added for Fix 18-A
+21. `src/runner.ts:9` — `join` imported from `'path'`; `resolve` must be added for Fix 18-A


### PR DESCRIPTION
## Summary
- Adds three testable implementation plans under `docs/plans/` derived from `docs/updates.md`
- Covers #18 (trend tracking + evidence_refs warning + adapter docs), #19 (multi-repo via `.retro.toml`), and skills best-practices conformance against [platform.claude.com/docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
- No code changes — planning only. Implementation happens in follow-up PRs (one per plan)

## Test plan
- [ ] Plans render correctly on GitHub
- [ ] Each plan has explicit acceptance criteria
- [ ] Source references in each plan match current `src/` line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)