### PR TITLE
fix: address PR #23 Copilot review (config dir, action-item cap, H1, test hygiene)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "date-fns": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@iarna/toml':
+        specifier: ^2.2.5
+        version: 2.2.5
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -237,6 +240,9 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -1298,6 +1304,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@iarna/toml@2.2.5': {}
 
   '@istanbuljs/schema@0.1.3': {}
 

--- a/src/analyzers/git.ts
+++ b/src/analyzers/git.ts
@@ -20,12 +20,18 @@ export interface GitAnalysisResult {
 }
 
 export class GitAnalyzer {
+  private cwd: string;
+
+  constructor(cwd: string = process.cwd()) {
+    this.cwd = cwd;
+  }
+
   /**
    * Check if current directory is a git repository
    */
   async isGitRepository(): Promise<boolean> {
     try {
-      execSync('git rev-parse --git-dir', { stdio: 'pipe' });
+      execSync('git rev-parse --git-dir', { stdio: 'pipe', cwd: this.cwd });
       return true;
     } catch {
       return false;
@@ -101,7 +107,7 @@ export class GitAnalyzer {
 
       const result = execSync(
         `git log --since="${dateStr}" --reverse --format="%H" | head -1`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       ).trim();
 
       if (result) {
@@ -125,7 +131,7 @@ export class GitAnalyzer {
       // Get commit hashes
       const hashesOutput = execSync(
         `git log ${fromRef}..${toRef} --format="%H"`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       ).trim();
 
       if (!hashesOutput) {
@@ -155,7 +161,7 @@ export class GitAnalyzer {
       // Get commit metadata
       const formatOutput = execSync(
         `git log -1 --format="%H%n%h%n%an%n%ae%n%aI%n%s%n%b" ${hash}`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       ).trim();
 
       const lines = formatOutput.split('\n');
@@ -163,7 +169,7 @@ export class GitAnalyzer {
       // Get file stats
       const statsOutput = execSync(
         `git diff-tree --no-commit-id --numstat -r ${hash}`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       ).trim();
 
       const files: FileChange[] = [];

--- a/src/analyzers/github.ts
+++ b/src/analyzers/github.ts
@@ -88,12 +88,18 @@ export interface GitHubAnalysisResult {
 }
 
 export class GitHubAnalyzer {
+  private cwd: string;
+
+  constructor(cwd: string = process.cwd()) {
+    this.cwd = cwd;
+  }
+
   /**
    * Check if gh CLI is available and authenticated
    */
   isAvailable(): boolean {
     try {
-      execSync('gh auth status', { stdio: 'pipe' });
+      execSync('gh auth status', { stdio: 'pipe', cwd: this.cwd });
       return true;
     } catch {
       return false;
@@ -200,7 +206,7 @@ export class GitHubAnalyzer {
       // Fetch reviews, comments, commits, files, and body for this PR
       const reviewsOutput = execSync(
         `gh pr view ${pr.number} --json reviews,comments,commits,files,body`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       );
 
       const data = JSON.parse(reviewsOutput);
@@ -474,7 +480,7 @@ export class GitHubAnalyzer {
     try {
       const output = execSync(
         'gh run list --limit 100 --json status,conclusion,name,createdAt,databaseId,headBranch',
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       );
 
       const runs = JSON.parse(output);
@@ -618,7 +624,7 @@ export class GitHubAnalyzer {
       const sinceArg = since ? `--search "created:>=${since}"` : '';
       const output = execSync(
         `gh pr list --state all --limit 50 ${sinceArg} --json number,title,author,state,createdAt,mergedAt,additions,deletions,changedFiles,labels`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: this.cwd }
       );
 
       const data = JSON.parse(output);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,8 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import pkg from '../package.json' with { type: 'json' };
 import { runRetro } from './runner.js';
-import type { RetroConfig } from './types.js';
+import { findRetroConfig } from './config.js';
+import type { RetroConfig, RepoConfig } from './types.js';
 
 const program = new Command();
 
@@ -29,9 +30,42 @@ program
   .option('--output <dir>', 'Output directory', 'docs/retrospectives')
   .option('--json', 'Output JSON only (no markdown)')
   .option('--quiet', 'Suppress progress output')
+  .option(
+    '--repo <path>',
+    'Repo path to analyze (repeatable for multi-repo). Overrides [[repos]] in .retro.toml when provided.',
+    (v: string, prev: string[]) => [...(prev || []), v],
+    [] as string[]
+  )
   .action(async (options) => {
     try {
       console.log(chalk.blue('🔄 Starting Agentic Retrospective...\n'));
+
+      // Lower-precedence defaults from .retro.toml
+      let toml: ReturnType<typeof findRetroConfig> = null;
+      try {
+        toml = findRetroConfig();
+      } catch (err) {
+        console.error(chalk.red('Error reading .retro.toml:'), err instanceof Error ? err.message : err);
+        process.exit(1);
+      }
+
+      if (toml?.retrospective?.sprint_id && !options.sprint) {
+        options.sprint = toml.retrospective.sprint_id;
+      }
+      if (toml?.retrospective?.output_dir && options.output === 'docs/retrospectives') {
+        options.output = toml.retrospective.output_dir;
+      }
+
+      // Repos: CLI --repo flags override config-file [[repos]]
+      let repos: RepoConfig[] | undefined;
+      if (Array.isArray(options.repo) && options.repo.length > 0) {
+        repos = (options.repo as string[]).map((p: string, i: number) => ({
+          path: p,
+          label: `repo-${i + 1}`,
+        }));
+      } else if (toml?.repos && toml.repos.length > 0) {
+        repos = toml.repos;
+      }
 
       const config: RetroConfig = {
         fromRef: options.from || '',
@@ -41,6 +75,7 @@ program
         agentLogsPath: options.logs,
         ciPath: options.ci,
         outputDir: options.output,
+        repos,
       };
 
       const result = await runRetro(config, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,30 +41,36 @@ program
       console.log(chalk.blue('🔄 Starting Agentic Retrospective...\n'));
 
       // Lower-precedence defaults from .retro.toml
-      let toml: ReturnType<typeof findRetroConfig> = null;
+      let tomlResult: ReturnType<typeof findRetroConfig> = null;
       try {
-        toml = findRetroConfig();
+        tomlResult = findRetroConfig();
       } catch (err) {
         console.error(chalk.red('Error reading .retro.toml:'), err instanceof Error ? err.message : err);
         process.exit(1);
       }
 
-      if (toml?.retrospective?.sprint_id && !options.sprint) {
-        options.sprint = toml.retrospective.sprint_id;
+      if (tomlResult?.config?.retrospective?.sprint_id && !options.sprint) {
+        options.sprint = tomlResult.config.retrospective.sprint_id;
       }
-      if (toml?.retrospective?.output_dir && options.output === 'docs/retrospectives') {
-        options.output = toml.retrospective.output_dir;
+      if (tomlResult?.config?.retrospective?.output_dir && options.output === 'docs/retrospectives') {
+        options.output = tomlResult.config.retrospective.output_dir;
       }
 
-      // Repos: CLI --repo flags override config-file [[repos]]
+      // Repos: CLI --repo flags override config-file [[repos]].
+      // Relative paths from .retro.toml are resolved against the config file's
+      // directory; CLI --repo paths are relative to process.cwd().
       let repos: RepoConfig[] | undefined;
       if (Array.isArray(options.repo) && options.repo.length > 0) {
         repos = (options.repo as string[]).map((p: string, i: number) => ({
           path: p,
           label: `repo-${i + 1}`,
         }));
-      } else if (toml?.repos && toml.repos.length > 0) {
-        repos = toml.repos;
+      } else if (tomlResult?.config?.repos && tomlResult.config.repos.length > 0) {
+        const { resolve: resolvePath } = await import('path');
+        repos = tomlResult.config.repos.map(r => ({
+          ...r,
+          path: resolvePath(tomlResult!.configDir, r.path),
+        }));
       }
 
       const config: RetroConfig = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,46 @@
+/**
+ * `.retro.toml` discovery and parsing.
+ *
+ * Walks upward from a starting directory (defaulting to `process.cwd()`)
+ * looking for a `.retro.toml` file. Parsed with `@iarna/toml` and returned
+ * as a typed object. Returns `null` when no configuration file is found
+ * up to the filesystem root.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { parse } from '@iarna/toml';
+
+export interface RetroToml {
+  retrospective?: {
+    sprint_id?: string;
+    output_dir?: string;
+    from?: string;
+    to?: string;
+  };
+  repos?: Array<{ path: string; label: string }>;
+}
+
+/**
+ * Walk up from `startDir` looking for `.retro.toml`. Returns `null` if not
+ * found. Throws a user-readable error if the file is present but malformed.
+ */
+export function findRetroConfig(startDir: string = process.cwd()): RetroToml | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, '.retro.toml');
+    if (existsSync(candidate)) {
+      try {
+        const raw = readFileSync(candidate, 'utf8');
+        return parse(raw) as unknown as RetroToml;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to parse ${candidate}: ${msg}`);
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // filesystem root
+    dir = parent;
+  }
+  return null;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,8 @@ export interface RetroToml {
  */
 export function findRetroConfig(startDir: string = process.cwd()): RetroToml | null {
   let dir = resolve(startDir);
-  while (true) {
+  // Walk upward until we hit the filesystem root (where dirname(dir) === dir).
+  for (;;) {
     const candidate = join(dir, '.retro.toml');
     if (existsSync(candidate)) {
       try {
@@ -39,8 +40,7 @@ export function findRetroConfig(startDir: string = process.cwd()): RetroToml | n
       }
     }
     const parent = dirname(dir);
-    if (parent === dir) break; // filesystem root
+    if (parent === dir) return null; // filesystem root
     dir = parent;
   }
-  return null;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,32 +15,47 @@ export interface RetroToml {
   retrospective?: {
     sprint_id?: string;
     output_dir?: string;
-    from?: string;
-    to?: string;
   };
   repos?: Array<{ path: string; label: string }>;
+}
+
+export interface RetroTomlResult {
+  config: RetroToml;
+  configDir: string;
 }
 
 /**
  * Walk up from `startDir` looking for `.retro.toml`. Returns `null` if not
  * found. Throws a user-readable error if the file is present but malformed.
+ *
+ * The returned `configDir` is the directory containing the file, which callers
+ * should use when resolving relative `[[repos]].path` entries.
+ *
+ * @param stopAt - optional upper bound for the walk (used in tests to keep
+ *   the search within a temp directory tree)
  */
-export function findRetroConfig(startDir: string = process.cwd()): RetroToml | null {
+export function findRetroConfig(
+  startDir: string = process.cwd(),
+  stopAt?: string
+): RetroTomlResult | null {
   let dir = resolve(startDir);
+  const ceiling = stopAt ? resolve(stopAt) : null;
   // Walk upward until we hit the filesystem root (where dirname(dir) === dir).
   for (;;) {
     const candidate = join(dir, '.retro.toml');
     if (existsSync(candidate)) {
       try {
         const raw = readFileSync(candidate, 'utf8');
-        return parse(raw) as unknown as RetroToml;
+        return { config: parse(raw) as unknown as RetroToml, configDir: dir };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         throw new Error(`Failed to parse ${candidate}: ${msg}`);
       }
     }
     const parent = dirname(dir);
-    if (parent === dir) return null; // filesystem root
+    // Stop at ceiling (for tests) or filesystem root.
+    if (ceiling !== null && dir === ceiling) return null;
+    if (parent === dir) return null;
     dir = parent;
   }
 }

--- a/src/report/generator.ts
+++ b/src/report/generator.ts
@@ -15,6 +15,50 @@ export class ReportGenerator {
   }
 
   /**
+   * Generate a multi-repo markdown report: one aggregate executive summary
+   * followed by per-repo sections (full per-repo markdown rendered under a
+   * "## Repository: <label>" header).
+   */
+  generateMultiRepoMarkdown(
+    aggregated: RetroReport,
+    perRepo: Array<{ label: string; path: string; report: RetroReport }>
+  ): string {
+    const sections: string[] = [];
+
+    sections.push(
+      `# Multi-Repo Sprint Retrospective: ${aggregated.sprint_id}
+
+**Period**: ${aggregated.period.from} to ${aggregated.period.to}
+**Generated**: ${aggregated.generated_at}
+**Repos**: ${perRepo.length} (${perRepo.map(r => r.label).join(', ')})
+**Data Completeness (avg)**: ${aggregated.data_completeness.percentage}%`
+    );
+
+    // Aggregate executive summary
+    sections.push(this.generateExecutiveSummary(aggregated));
+
+    // Quick per-repo commit table
+    let repoTable = `## Per-Repo Breakdown\n\n| Repo | Commits | Lines +/- | Decisions | Agent commits |\n|------|---------|-----------|-----------|----------------|\n`;
+    for (const r of perRepo) {
+      const s = r.report.summary;
+      repoTable += `| ${r.label} | ${s.commits} | +${s.lines_added}/-${s.lines_removed} | ${s.decisions_logged} | ${s.agent_commits} (${s.agent_commit_percentage}%) |\n`;
+    }
+    sections.push(repoTable);
+
+    // Aggregate findings + action items (already capped at 5)
+    sections.push(this.generateActionItems(aggregated.action_items));
+
+    // Per-repo sections (full reports inline)
+    for (const r of perRepo) {
+      sections.push(
+        `---\n\n## Repository: ${r.label} (\`${r.path}\`)\n\n${this.generateMarkdown(r.report)}`
+      );
+    }
+
+    return sections.join('\n\n---\n\n');
+  }
+
+  /**
    * Generate markdown report from RetroReport
    */
   generateMarkdown(report: RetroReport): string {

--- a/src/report/generator.ts
+++ b/src/report/generator.ts
@@ -48,10 +48,10 @@ export class ReportGenerator {
     // Aggregate findings + action items (already capped at 5)
     sections.push(this.generateActionItems(aggregated.action_items));
 
-    // Per-repo sections (full reports inline)
+    // Per-repo sections (body only — no H1 so the combined doc has one root heading)
     for (const r of perRepo) {
       sections.push(
-        `---\n\n## Repository: ${r.label} (\`${r.path}\`)\n\n${this.generateMarkdown(r.report)}`
+        `---\n\n## Repository: ${r.label} (\`${r.path}\`)\n\n${this.generateMarkdown(r.report, false)}`
       );
     }
 
@@ -59,13 +59,19 @@ export class ReportGenerator {
   }
 
   /**
-   * Generate markdown report from RetroReport
+   * Generate markdown report from RetroReport.
+   *
+   * @param includeHeader - when false, omits the top-level H1 header (used
+   *   when embedding per-repo reports inside a multi-repo document so the
+   *   combined output has only one H1).
    */
-  generateMarkdown(report: RetroReport): string {
+  generateMarkdown(report: RetroReport, includeHeader: boolean = true): string {
     const sections: string[] = [];
 
     // Header
-    sections.push(this.generateHeader(report));
+    if (includeHeader) {
+      sections.push(this.generateHeader(report));
+    }
 
     // TL;DR Quick Summary (Phase 1 addition)
     sections.push(this.humanReportGenerator.generateQuickSummary(report));

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { join, resolve, isAbsolute } from 'path';
 import type {
   RetroConfig,
   RetroReport,
@@ -25,6 +25,7 @@ import type {
   ToolsSummary,
   DecisionAnalysis,
   DecisionRecord,
+  RepoConfig,
 } from './types.js';
 import { GitAnalyzer } from './analyzers/git.js';
 import { DecisionAnalyzer } from './analyzers/decisions.js';
@@ -48,6 +49,13 @@ export interface RunResult {
   report?: RetroReport;
   alerts?: Alert[];
   error?: string;
+  perRepo?: PerRepoResult[];
+}
+
+export interface PerRepoResult {
+  label: string;
+  path: string;
+  report: RetroReport;
 }
 
 export async function runRetro(
@@ -70,6 +78,13 @@ export class RetroRunner {
   }
 
   async run(): Promise<RunResult> {
+    if (this.config.repos && this.config.repos.length > 0) {
+      return this.runMultiRepo();
+    }
+    return this.runSingleRepo();
+  }
+
+  private async runSingleRepo(): Promise<RunResult> {
     try {
       // Phase 0: Validate environment
       this.log('Phase 0: Validating environment...');
@@ -112,16 +127,108 @@ export class RetroRunner {
     }
   }
 
+  /**
+   * Multi-repo orchestration: iterate each configured repo, run a
+   * per-repo pipeline, then aggregate into a combined report.
+   */
+  private async runMultiRepo(): Promise<RunResult> {
+    try {
+      const repos = this.config.repos ?? [];
+      const perRepo: PerRepoResult[] = [];
+      const perRepoEvidence: Array<{ label: string; path: string; evidence: EvidenceMap }> = [];
+
+      for (const repo of repos) {
+        const repoCwd = isAbsolute(repo.path) ? repo.path : resolve(process.cwd(), repo.path);
+        this.log(`\n=== Repo: ${repo.label} (${repoCwd}) ===`);
+        const { report, evidenceMap } = await this.runPipelineForRepo(repoCwd, repo);
+        perRepo.push({ label: repo.label, path: repoCwd, report });
+        perRepoEvidence.push({ label: repo.label, path: repoCwd, evidence: evidenceMap });
+      }
+
+      // Aggregate
+      const aggregated = this.aggregateMultiRepo(perRepo);
+
+      // Write outputs: aggregate markdown + JSON
+      this.log('Phase 5: Writing multi-repo outputs...');
+      const outputPath = await this.writeMultiRepoOutputs(perRepo, aggregated, perRepoEvidence);
+
+      return {
+        success: true,
+        outputPath,
+        report: aggregated,
+        alerts: this.generateAlerts(aggregated),
+        perRepo,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Run the full collection + analysis pipeline against a single repo
+   * at an arbitrary cwd. Returns the per-repo report + evidence map
+   * without writing any files.
+   */
+  private async runPipelineForRepo(
+    repoCwd: string,
+    repo: RepoConfig
+  ): Promise<{ report: RetroReport; evidenceMap: EvidenceMap }> {
+    // Use a fresh findings/gaps buffer per repo so findings are attributed.
+    const savedFindings = this.findings;
+    const savedGaps = this.gaps;
+    this.findings = [];
+    this.gaps = [];
+
+    try {
+      // Validate git at the repo path
+      const gitAnalyzer = new GitAnalyzer(repoCwd);
+      const isGit = await gitAnalyzer.isGitRepository();
+      if (!isGit) {
+        throw new Error(`Not a git repository: ${repoCwd}`);
+      }
+
+      // Per-repo paths default to <repoCwd>/.logs/... unless the config paths
+      // were given as absolute paths (in which case they are shared across repos).
+      const decisionsPath = isAbsolute(this.config.decisionsPath)
+        ? this.config.decisionsPath
+        : join(repoCwd, this.config.decisionsPath);
+      const agentLogsPath = isAbsolute(this.config.agentLogsPath)
+        ? this.config.agentLogsPath
+        : join(repoCwd, this.config.agentLogsPath);
+
+      const data = await this.collectDataAt(repoCwd, decisionsPath, agentLogsPath);
+      const evidenceMap = this.buildEvidenceMap(data);
+      const scores = await this.analyzeSprit(data);
+      const report = this.generateReport(data, scores, evidenceMap);
+
+      // Tag report with repo label for multi-repo rendering
+      report.sprint_id = `${this.config.sprintId}/${repo.label}`;
+
+      return { report, evidenceMap };
+    } finally {
+      // Merge per-repo findings/gaps back so the overall runner state
+      // reflects all work done (useful for debugging), but restore the
+      // buffers so the caller sees only its own state.
+      const repoFindings = this.findings;
+      const repoGaps = this.gaps;
+      this.findings = savedFindings.concat(repoFindings);
+      this.gaps = savedGaps.concat(repoGaps);
+    }
+  }
+
   private log(message: string): void {
     if (this.options.verbose) {
       console.log(message);
     }
   }
 
-  private async validateEnvironment(): Promise<{ valid: boolean; error?: string }> {
+  private async validateEnvironment(cwd: string = process.cwd()): Promise<{ valid: boolean; error?: string }> {
     // Check if we're in a git repository
     try {
-      const gitAnalyzer = new GitAnalyzer();
+      const gitAnalyzer = new GitAnalyzer(cwd);
       const isGit = await gitAnalyzer.isGitRepository();
       if (!isGit) {
         return {
@@ -139,6 +246,14 @@ export class RetroRunner {
   }
 
   private async collectData(): Promise<CollectedData> {
+    return this.collectDataAt(process.cwd(), this.config.decisionsPath, this.config.agentLogsPath);
+  }
+
+  private async collectDataAt(
+    repoCwd: string,
+    decisionsPath: string,
+    agentLogsPath: string
+  ): Promise<CollectedData> {
     const data: CollectedData = {
       git: null,
       decisions: null,
@@ -154,7 +269,7 @@ export class RetroRunner {
     };
 
     // Collect git data (required)
-    const gitAnalyzer = new GitAnalyzer();
+    const gitAnalyzer = new GitAnalyzer(repoCwd);
     const gitResult = await gitAnalyzer.analyze(this.config.fromRef, this.config.toRef);
 
     // Phase 2.1: Detect agent commits
@@ -224,8 +339,8 @@ export class RetroRunner {
     }
 
     // Collect decision logs (optional)
-    if (existsSync(this.config.decisionsPath)) {
-      const decisionAnalyzer = new DecisionAnalyzer(this.config.decisionsPath);
+    if (existsSync(decisionsPath)) {
+      const decisionAnalyzer = new DecisionAnalyzer(decisionsPath);
       const decisionResult = decisionAnalyzer.analyze();
       data.decisions = {
         records: decisionResult.records,
@@ -325,19 +440,19 @@ export class RetroRunner {
         gap_type: 'missing_decisions',
         severity: 'high',
         impact: 'Cannot evaluate decision quality or boundary discipline',
-        recommendation: `Create decision log directory: mkdir -p ${this.config.decisionsPath}\nSee docs/fixing-telemetry-gaps.md`,
+        recommendation: `Create decision log directory: mkdir -p ${decisionsPath}\nSee docs/fixing-telemetry-gaps.md`,
       });
     }
 
     // Collect agent logs (optional)
-    if (existsSync(this.config.agentLogsPath)) {
-      data.agentLogs = this.loadAgentLogs();
+    if (existsSync(agentLogsPath)) {
+      data.agentLogs = this.loadAgentLogs(agentLogsPath);
     } else {
       this.addTelemetryGap({
         gap_type: 'missing_agent_logs',
         severity: 'medium',
         impact: 'Cannot analyze agent collaboration patterns or inner loop health',
-        recommendation: `Agent logs not found at ${this.config.agentLogsPath}\nSee docs/fixing-telemetry-gaps.md`,
+        recommendation: `Agent logs not found at ${agentLogsPath}\nSee docs/fixing-telemetry-gaps.md`,
       });
     }
 
@@ -352,8 +467,9 @@ export class RetroRunner {
       });
     }
 
-    // Phase 1: Collect human insights from prompt and feedback logs
-    const logsBasePath = join(process.cwd(), '.logs');
+    // Phase 1: Collect human insights from prompt and feedback logs.
+    // Rooted at repoCwd so multi-repo mode uses each repo's own .logs.
+    const logsBasePath = join(repoCwd, '.logs');
     const humanInsightsAnalyzer = new HumanInsightsAnalyzer(logsBasePath);
     // Load logs first so hasData() can check, analyze() will skip re-loading
     humanInsightsAnalyzer.loadLogs();
@@ -402,7 +518,7 @@ export class RetroRunner {
     }
 
     // Collect GitHub PR data
-    const githubAnalyzer = new GitHubAnalyzer();
+    const githubAnalyzer = new GitHubAnalyzer(repoCwd);
     if (githubAnalyzer.isAvailable()) {
       const githubAnalysis = await githubAnalyzer.analyze();
       if (githubAnalysis.totalPRs > 0) {
@@ -564,14 +680,14 @@ export class RetroRunner {
     return data;
   }
 
-  private loadAgentLogs(): unknown[] | null {
+  private loadAgentLogs(agentLogsPath: string = this.config.agentLogsPath): unknown[] | null {
     try {
-      const files = readdirSync(this.config.agentLogsPath);
+      const files = readdirSync(agentLogsPath);
       const logs: unknown[] = [];
 
       for (const file of files) {
         if (file.endsWith('.jsonl') || file.endsWith('.json')) {
-          const content = readFileSync(join(this.config.agentLogsPath, file), 'utf-8');
+          const content = readFileSync(join(agentLogsPath, file), 'utf-8');
           if (file.endsWith('.jsonl')) {
             content.split('\n').filter(Boolean).forEach(line => {
               try {
@@ -1050,6 +1166,205 @@ export class RetroRunner {
     }
 
     return alerts;
+  }
+
+  /**
+   * Aggregate per-repo reports into a single RetroReport. Used for the
+   * executive summary of a multi-repo retrospective.
+   *
+   * Aggregation rules (plan §Phase 19-D):
+   * - Scores: commit-count-weighted average across repos
+   * - Findings: union, deduplicated by (category, title)
+   * - Action items: capped at 5 total (constitution)
+   * - data_completeness: averaged
+   * - generated_at: single timestamp (run start)
+   */
+  private aggregateMultiRepo(perRepo: PerRepoResult[]): RetroReport {
+    const now = new Date().toISOString();
+
+    // Sum base summary fields
+    const summary = {
+      commits: 0,
+      contributors: 0,
+      human_contributors: 0,
+      agent_contributors: 0,
+      lines_added: 0,
+      lines_removed: 0,
+      decisions_logged: 0,
+      agent_commits: 0,
+      agent_commit_percentage: 0,
+    };
+    for (const r of perRepo) {
+      summary.commits += r.report.summary.commits;
+      summary.contributors += r.report.summary.contributors;
+      summary.human_contributors += r.report.summary.human_contributors;
+      summary.agent_contributors += r.report.summary.agent_contributors;
+      summary.lines_added += r.report.summary.lines_added;
+      summary.lines_removed += r.report.summary.lines_removed;
+      summary.decisions_logged += r.report.summary.decisions_logged;
+      summary.agent_commits += r.report.summary.agent_commits;
+    }
+    summary.agent_commit_percentage = summary.commits > 0
+      ? Math.round((summary.agent_commits / summary.commits) * 100)
+      : 0;
+
+    // Weighted score aggregation: weight by per-repo commit count.
+    const scoreKeys: Array<keyof Scores> = [
+      'delivery_predictability',
+      'test_loop_completeness',
+      'quality_maintainability',
+      'security_posture',
+      'collaboration_efficiency',
+      'decision_hygiene',
+    ];
+    const aggregatedScores = {} as Scores;
+    for (const key of scoreKeys) {
+      let weightedSum = 0;
+      let totalWeight = 0;
+      const evidence: string[] = [];
+      let confidence: Score['confidence'] = 'none';
+      for (const r of perRepo) {
+        const s = r.report.scores[key];
+        const weight = r.report.summary.commits;
+        if (s.score !== null && weight > 0) {
+          weightedSum += s.score * weight;
+          totalWeight += weight;
+          evidence.push(`[${r.label}] ${s.evidence.join('; ')}`);
+          // Confidence: take the highest seen
+          if (confidence === 'none') confidence = s.confidence;
+          else if (s.confidence === 'high') confidence = 'high';
+          else if (s.confidence === 'medium' && confidence !== 'high') confidence = 'medium';
+        }
+      }
+      aggregatedScores[key] = totalWeight > 0
+        ? {
+            score: Math.round((weightedSum / totalWeight) * 10) / 10,
+            confidence,
+            evidence,
+          }
+        : { score: null, confidence: 'none', evidence: [] };
+    }
+
+    // Dedupe findings by (category, title)
+    const seen = new Set<string>();
+    const findings: Finding[] = [];
+    for (const r of perRepo) {
+      for (const f of r.report.findings) {
+        const key = `${f.category}|${f.title}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          findings.push({ ...f, evidence: [...f.evidence, `repo:${r.label}`] });
+        }
+      }
+    }
+
+    // Collect + cap action items at 5 (constitution)
+    const allActions: ActionItem[] = [];
+    for (const r of perRepo) allActions.push(...r.report.action_items);
+    // Stable de-dupe by (action text)
+    const seenActions = new Set<string>();
+    const actionItems: ActionItem[] = [];
+    for (const a of allActions) {
+      if (!seenActions.has(a.action)) {
+        seenActions.add(a.action);
+        actionItems.push(a);
+      }
+    }
+    const cappedActions = actionItems.slice(0, 5);
+
+    // Average data completeness
+    const avgPct = perRepo.length > 0
+      ? Math.round(perRepo.reduce((sum, r) => sum + r.report.data_completeness.percentage, 0) / perRepo.length)
+      : 0;
+    // Union source flags: true if any repo had it
+    const unionSources = {
+      git: perRepo.some(r => r.report.data_completeness.sources.git),
+      decisions: perRepo.some(r => r.report.data_completeness.sources.decisions),
+      agent_logs: perRepo.some(r => r.report.data_completeness.sources.agent_logs),
+      ci: perRepo.some(r => r.report.data_completeness.sources.ci),
+      tests: perRepo.some(r => r.report.data_completeness.sources.tests),
+    };
+    const allGaps: TelemetryGap[] = [];
+    for (const r of perRepo) allGaps.push(...r.report.data_completeness.gaps);
+
+    return {
+      sprint_id: this.config.sprintId,
+      period: {
+        from: this.config.fromRef || 'HEAD~100',
+        to: this.config.toRef,
+      },
+      generated_at: now,
+      data_completeness: {
+        percentage: avgPct,
+        sources: unionSources,
+        gaps: allGaps,
+      },
+      summary,
+      scores: aggregatedScores,
+      findings,
+      wins: [],
+      risks: [],
+      action_items: cappedActions,
+      evidence_map: {
+        commits: {},
+        decisions: {},
+        orphans: { commits_without_context: [], decisions_without_implementation: [] },
+      },
+      metadata: {
+        tool_version: '0.3.0',
+        schema_version: '1.2',
+        generated_by: 'agentic-retrospective',
+      },
+    };
+  }
+
+  private async writeMultiRepoOutputs(
+    perRepo: PerRepoResult[],
+    aggregated: RetroReport,
+    perRepoEvidence: Array<{ label: string; path: string; evidence: EvidenceMap }>
+  ): Promise<string> {
+    const outputPath = join(this.config.outputDir, this.config.sprintId);
+    mkdirSync(outputPath, { recursive: true });
+
+    // Write aggregate JSON
+    writeFileSync(
+      join(outputPath, 'retrospective.json'),
+      JSON.stringify(
+        {
+          aggregate: aggregated,
+          repos: perRepo.map(r => ({ label: r.label, path: r.path, report: r.report })),
+        },
+        null,
+        2
+      )
+    );
+
+    // Per-repo evidence maps combined
+    const combinedEvidence: Record<string, EvidenceMap> = {};
+    for (const e of perRepoEvidence) combinedEvidence[e.label] = e.evidence;
+    writeFileSync(
+      join(outputPath, 'evidence_map.json'),
+      JSON.stringify(combinedEvidence, null, 2)
+    );
+
+    // Alerts
+    const alertsOutput: AlertsOutput = {
+      alerts: this.generateAlerts(aggregated),
+      generated_at: new Date().toISOString(),
+    };
+    writeFileSync(join(outputPath, 'alerts.json'), JSON.stringify(alertsOutput, null, 2));
+
+    // Markdown: aggregate summary + per-repo sections
+    if (!this.options.jsonOnly) {
+      const generator = new ReportGenerator();
+      const markdown = generator.generateMultiRepoMarkdown(
+        aggregated,
+        perRepo.map(r => ({ label: r.label, path: r.path, report: r.report }))
+      );
+      writeFileSync(join(outputPath, 'retrospective.md'), markdown);
+    }
+
+    return outputPath;
   }
 
   private async writeOutputs(report: RetroReport, evidenceMap: EvidenceMap): Promise<string> {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -204,6 +204,9 @@ export class RetroRunner {
       const scores = await this.analyzeSprit(data);
       const report = this.generateReport(data, scores, evidenceMap);
 
+      // Cap per-repo action items at 5 (constitution §48 applies to every retro section)
+      report.action_items = report.action_items.slice(0, 5);
+
       // Tag report with repo label for multi-repo rendering
       report.sprint_id = `${this.config.sprintId}/${repo.label}`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -496,6 +496,11 @@ export interface RetroReport {
 }
 
 // Configuration Types
+export interface RepoConfig {
+  path: string;    // Absolute or relative; resolved at runtime
+  label: string;   // Human-readable label used in reports (e.g., "frontend")
+}
+
 export interface RetroConfig {
   fromRef: string;
   toRef: string;
@@ -504,6 +509,7 @@ export interface RetroConfig {
   agentLogsPath: string;
   ciPath?: string;
   outputDir: string;
+  repos?: RepoConfig[];   // Empty/absent = single-repo (cwd)
 }
 
 // Alert Types

--- a/test/integration/multi-repo.test.ts
+++ b/test/integration/multi-repo.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Integration tests for multi-repo mode (issue #19).
+ *
+ * Covers the 7 cases from docs/plans/issue-19-plan.md §Integration Testing:
+ *   1. single-repo default unchanged when no config/flags
+ *   2. --repo ../a runs against that path
+ *   3. two --repo flags produce aggregate + per-repo sections
+ *   4. loads .retro.toml from parent dir
+ *   5. CLI --repo overrides .retro.toml repos
+ *   6. aggregate scores are commit-weighted
+ *   7. action items capped at 5 across all repos
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync, spawnSync } from 'child_process';
+import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { createTempDir, type TempDir } from '../helpers/temp-dir.js';
+import { runRetro } from '../../src/runner.js';
+import type { RetroConfig } from '../../src/types.js';
+
+function initGitRepo(cwd: string): void {
+  execSync('git init', { cwd, stdio: 'pipe' });
+  execSync('git config user.email "test@example.com"', { cwd, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd, stdio: 'pipe' });
+}
+
+function makeCommit(cwd: string, message: string, files: Record<string, string>): string {
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(cwd, path);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, content);
+  }
+  execSync('git add -A', { cwd, stdio: 'pipe' });
+  execSync(`git commit -m "${message}"`, { cwd, stdio: 'pipe' });
+  return execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
+}
+
+describe('Multi-repo mode (issue #19)', () => {
+  let tempDir: TempDir;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir('retro-multirepo-');
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    tempDir.cleanup();
+  });
+
+  test('1: single-repo default unchanged when no config/flags', async () => {
+    const repoA = tempDir.createDir('repo-a');
+    initGitRepo(repoA);
+    const first = makeCommit(repoA, 'Initial', { 'README.md': 'a' });
+    makeCommit(repoA, 'feat: x', { 'src/x.ts': 'x' });
+
+    process.chdir(repoA);
+    const config: RetroConfig = {
+      fromRef: first,
+      toRef: 'HEAD',
+      sprintId: 'single',
+      decisionsPath: join(repoA, '.logs/decisions'),
+      agentLogsPath: join(repoA, '.logs/agents'),
+      outputDir: join(tempDir.path, 'out-single'),
+    };
+    const result = await runRetro(config, { verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(result.perRepo).toBeUndefined(); // single-repo path
+    expect(result.report!.summary.commits).toBe(1);
+  });
+
+  test('2: repos=[path] runs against that path', async () => {
+    const repoA = tempDir.createDir('repo-a');
+    initGitRepo(repoA);
+    const first = makeCommit(repoA, 'Initial', { 'README.md': 'a' });
+    makeCommit(repoA, 'feat: first', { 'src/x.ts': 'x' });
+    makeCommit(repoA, 'feat: second', { 'src/y.ts': 'y' });
+
+    // cwd is the tempDir; repo is a sibling directory
+    process.chdir(tempDir.path);
+
+    const config: RetroConfig = {
+      fromRef: first,
+      toRef: 'HEAD',
+      sprintId: 'single-as-multi',
+      decisionsPath: '.logs/decisions',
+      agentLogsPath: '.logs/agents',
+      outputDir: join(tempDir.path, 'out-single-as-multi'),
+      repos: [{ path: repoA, label: 'a' }],
+    };
+    const result = await runRetro(config, { verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(result.perRepo).toHaveLength(1);
+    expect(result.perRepo![0].label).toBe('a');
+    expect(result.perRepo![0].report.summary.commits).toBe(2);
+  });
+
+  test('3: two repos produce aggregate + per-repo sections', async () => {
+    const repoA = tempDir.createDir('repo-a');
+    initGitRepo(repoA);
+    const firstA = makeCommit(repoA, 'Initial A', { 'README.md': 'a' });
+    makeCommit(repoA, 'feat: a-feat', { 'a.ts': 'a' });
+    makeCommit(repoA, 'fix: a-fix', { 'a.ts': 'a2' });
+
+    const repoB = tempDir.createDir('repo-b');
+    initGitRepo(repoB);
+    const firstB = makeCommit(repoB, 'Initial B', { 'README.md': 'b' });
+    makeCommit(repoB, 'feat: b-feat', { 'b.ts': 'b' });
+
+    process.chdir(tempDir.path);
+
+    const config: RetroConfig = {
+      fromRef: '',
+      toRef: 'HEAD',
+      sprintId: 'multi',
+      decisionsPath: '.logs/decisions',
+      agentLogsPath: '.logs/agents',
+      outputDir: join(tempDir.path, 'out-multi'),
+      repos: [
+        { path: repoA, label: 'frontend' },
+        { path: repoB, label: 'api' },
+      ],
+    };
+
+    // Override default fromRef per repo by setting to the first commit of repoA
+    // Since fromRefs are shared across repos in this design, use ''
+    void firstA;
+    void firstB;
+
+    const result = await runRetro(config, { verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(result.perRepo).toHaveLength(2);
+
+    // Check the aggregate output files
+    const outDir = join(tempDir.path, 'out-multi', 'multi');
+    expect(existsSync(join(outDir, 'retrospective.json'))).toBe(true);
+    expect(existsSync(join(outDir, 'retrospective.md'))).toBe(true);
+
+    const md = readFileSync(join(outDir, 'retrospective.md'), 'utf-8');
+    expect(md).toContain('Multi-Repo Sprint Retrospective');
+    expect(md).toContain('## Repository: frontend');
+    expect(md).toContain('## Repository: api');
+    expect(md).toContain('Per-Repo Breakdown');
+  });
+
+  test('4: .retro.toml in parent dir is discovered and parsed', async () => {
+    const parent = tempDir.path;
+    const nested = tempDir.createDir('deep/work');
+
+    writeFileSync(
+      join(parent, '.retro.toml'),
+      `[retrospective]
+sprint_id = "toml-sprint"
+`
+    );
+
+    process.chdir(nested);
+    const { findRetroConfig } = await import('../../src/config.js');
+    const result = findRetroConfig();
+
+    expect(result).not.toBeNull();
+    expect(result?.retrospective?.sprint_id).toBe('toml-sprint');
+  });
+
+  test('5: CLI --repo overrides .retro.toml repos (unit-level check via config)', async () => {
+    // Drive via the CLI logic: simulate by ensuring the order of precedence
+    // — if both are present, CLI wins. We verify by constructing a RetroConfig
+    // directly and confirming that repos passed at construction time are the
+    // ones honored.
+    const repoCli = tempDir.createDir('cli-repo');
+    initGitRepo(repoCli);
+    makeCommit(repoCli, 'Initial', { 'R.md': 'r' });
+    makeCommit(repoCli, 'feat: cli-only', { 's.ts': 's' });
+
+    // Write a .retro.toml that mentions a completely different repo
+    const fakeTomlPath = tempDir.createDir('toml-parent');
+    writeFileSync(
+      join(fakeTomlPath, '.retro.toml'),
+      `[[repos]]
+path = "./nonexistent"
+label = "should-be-overridden"
+`
+    );
+
+    process.chdir(fakeTomlPath);
+    const config: RetroConfig = {
+      fromRef: '',
+      toRef: 'HEAD',
+      sprintId: 'precedence',
+      decisionsPath: '.logs/decisions',
+      agentLogsPath: '.logs/agents',
+      outputDir: join(tempDir.path, 'out-precedence'),
+      repos: [{ path: repoCli, label: 'cli-wins' }], // simulates what cli.ts does
+    };
+    const result = await runRetro(config, { verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(result.perRepo).toHaveLength(1);
+    expect(result.perRepo![0].label).toBe('cli-wins');
+  });
+
+  test('6: aggregate scores are commit-weighted', async () => {
+    // repoA has many small commits (good delivery_predictability -> high score)
+    // repoB has one very large commit (low delivery_predictability -> low score)
+    const repoA = tempDir.createDir('heavy');
+    initGitRepo(repoA);
+    makeCommit(repoA, 'init', { 'a.ts': 'a' });
+    for (let i = 0; i < 10; i++) {
+      makeCommit(repoA, `feat: small ${i}`, { [`f${i}.ts`]: 'x\n' });
+    }
+
+    const repoB = tempDir.createDir('light');
+    initGitRepo(repoB);
+    makeCommit(repoB, 'init', { 'b.ts': 'b' });
+    // single huge commit (>500 lines) to drive score down
+    const big = Array.from({ length: 800 }, (_, i) => `line${i}`).join('\n');
+    makeCommit(repoB, 'feat: big', { 'big.ts': big });
+
+    process.chdir(tempDir.path);
+    const config: RetroConfig = {
+      fromRef: '',
+      toRef: 'HEAD',
+      sprintId: 'weighted',
+      decisionsPath: '.logs/decisions',
+      agentLogsPath: '.logs/agents',
+      outputDir: join(tempDir.path, 'out-weighted'),
+      repos: [
+        { path: repoA, label: 'heavy' },
+        { path: repoB, label: 'light' },
+      ],
+    };
+    const result = await runRetro(config, { verbose: false });
+    expect(result.success).toBe(true);
+
+    // Heavy repo (more commits) should dominate the weighted aggregate.
+    const heavy = result.perRepo!.find(r => r.label === 'heavy')!;
+    const light = result.perRepo!.find(r => r.label === 'light')!;
+    expect(heavy.report.summary.commits).toBeGreaterThan(light.report.summary.commits);
+
+    const aggScore = result.report!.scores.delivery_predictability.score;
+    const heavyScore = heavy.report.scores.delivery_predictability.score;
+    const lightScore = light.report.scores.delivery_predictability.score;
+
+    // Weighted average must sit between the two repo scores, closer to the
+    // heavier-weight (more-commits) repo score.
+    if (aggScore !== null && heavyScore !== null && lightScore !== null) {
+      const minScore = Math.min(heavyScore, lightScore);
+      const maxScore = Math.max(heavyScore, lightScore);
+      expect(aggScore).toBeGreaterThanOrEqual(minScore);
+      expect(aggScore).toBeLessThanOrEqual(maxScore);
+      // Should be closer to heavy's score than a naive average would be.
+      const naiveAvg = (heavyScore + lightScore) / 2;
+      expect(Math.abs(aggScore - heavyScore)).toBeLessThanOrEqual(Math.abs(naiveAvg - heavyScore) + 0.1);
+    }
+  });
+
+  test('7: aggregate action items never exceed 5 across all repos', async () => {
+    // Create two repos each with no logs so each generates several telemetry
+    // gap action items. The aggregate should still cap at 5.
+    const repoA = tempDir.createDir('gaps-a');
+    initGitRepo(repoA);
+    makeCommit(repoA, 'init', { 'a.ts': 'a' });
+    makeCommit(repoA, 'feat: x', { 'x.ts': 'x' });
+
+    const repoB = tempDir.createDir('gaps-b');
+    initGitRepo(repoB);
+    makeCommit(repoB, 'init', { 'b.ts': 'b' });
+    makeCommit(repoB, 'feat: y', { 'y.ts': 'y' });
+
+    process.chdir(tempDir.path);
+    const config: RetroConfig = {
+      fromRef: '',
+      toRef: 'HEAD',
+      sprintId: 'capped',
+      decisionsPath: '.logs/decisions',
+      agentLogsPath: '.logs/agents',
+      outputDir: join(tempDir.path, 'out-capped'),
+      repos: [
+        { path: repoA, label: 'a' },
+        { path: repoB, label: 'b' },
+      ],
+    };
+    const result = await runRetro(config, { verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(result.report!.action_items.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// Separate describe block: CLI smoke coverage of --repo flag
+describe('CLI --repo flag (issue #19)', () => {
+  let tempDir: TempDir;
+  let originalCwd: string;
+  let cliPath: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir('retro-cli-multirepo-');
+    originalCwd = process.cwd();
+    cliPath = join(originalCwd, 'dist', 'cli.js');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    tempDir.cleanup();
+  });
+
+  test('--help lists --repo', () => {
+    const r = spawnSync('node', [cliPath, '--help'], { encoding: 'utf-8' });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('--repo');
+  });
+});

--- a/test/integration/multi-repo.test.ts
+++ b/test/integration/multi-repo.test.ts
@@ -11,7 +11,7 @@
  *   7. action items capped at 5 across all repos
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { execSync, spawnSync } from 'child_process';
 import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
@@ -164,7 +164,7 @@ sprint_id = "toml-sprint"
     const result = findRetroConfig();
 
     expect(result).not.toBeNull();
-    expect(result?.retrospective?.sprint_id).toBe('toml-sprint');
+    expect(result?.config?.retrospective?.sprint_id).toBe('toml-sprint');
   });
 
   test('5: CLI --repo overrides .retro.toml repos (unit-level check via config)', async () => {
@@ -289,6 +289,11 @@ label = "should-be-overridden"
 
     expect(result.success).toBe(true);
     expect(result.report!.action_items.length).toBeLessThanOrEqual(5);
+
+    // Per-repo reports embedded in the combined output must also be capped at 5.
+    for (const r of result.perRepo ?? []) {
+      expect(r.report.action_items.length).toBeLessThanOrEqual(5);
+    }
   });
 });
 
@@ -297,6 +302,13 @@ describe('CLI --repo flag (issue #19)', () => {
   let tempDir: TempDir;
   let originalCwd: string;
   let cliPath: string;
+
+  beforeAll(() => {
+    // Build dist/ so the CLI entry point exists before the test shells out to it.
+    // This is a no-op if dist/ is already up-to-date (tsc is incremental).
+    const root = process.cwd();
+    execSync('pnpm run build', { cwd: root, stdio: 'pipe' });
+  });
 
   beforeEach(() => {
     tempDir = createTempDir('retro-cli-multirepo-');

--- a/test/unit/analyzers/git.test.ts
+++ b/test/unit/analyzers/git.test.ts
@@ -111,6 +111,51 @@ describe('GitAnalyzer', () => {
       const result = await analyzer.isGitRepository();
       expect(result).toBe(false);
     });
+
+    test('passes explicit cwd to execSync when provided', async () => {
+      mockExecSync.mockReturnValue('.git');
+      const customCwd = '/some/other/path';
+      const analyzer = new GitAnalyzer(customCwd);
+      await analyzer.isGitRepository();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'git rev-parse --git-dir',
+        expect.objectContaining({ cwd: customCwd })
+      );
+    });
+
+    test('defaults cwd to process.cwd() when no arg', async () => {
+      mockExecSync.mockReturnValue('.git');
+      const analyzer = new GitAnalyzer();
+      await analyzer.isGitRepository();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'git rev-parse --git-dir',
+        expect.objectContaining({ cwd: process.cwd() })
+      );
+    });
+  });
+
+  describe('cwd parameter threading', () => {
+    test('analyze() threads cwd through to all git commands', async () => {
+      const customCwd = '/tmp/fake-repo-path';
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('--format="%H"') && !cmd.includes('-1')) return '';
+        return '';
+      });
+
+      const analyzer = new GitAnalyzer(customCwd);
+      await analyzer.analyze('HEAD~5', 'HEAD');
+
+      // Every execSync call should have been issued with the custom cwd
+      const calls = mockExecSync.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const call of calls) {
+        const opts = call[1] as { cwd?: string } | undefined;
+        expect(opts?.cwd).toBe(customCwd);
+      }
+    });
   });
 
   describe('analyze', () => {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for findRetroConfig().
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { createTempDir, type TempDir } from '../helpers/temp-dir.js';
+import { findRetroConfig } from '../../src/config.js';
+
+describe('findRetroConfig', () => {
+  let tempDir: TempDir;
+
+  beforeEach(() => {
+    tempDir = createTempDir('retro-config-');
+  });
+
+  afterEach(() => {
+    tempDir.cleanup();
+  });
+
+  test('returns null when no .retro.toml exists anywhere up to root', () => {
+    // tmpdir should not contain a .retro.toml all the way up
+    // (this is a best-effort assumption — if one exists in /tmp it would shadow)
+    // Create a nested dir and search from there.
+    const nested = tempDir.createDir('a/b/c');
+    const result = findRetroConfig(nested);
+    // If any ancestor happens to have a `.retro.toml`, this test would fail.
+    // Under CI / dev environments that is not expected.
+    expect(result).toBeNull();
+  });
+
+  test('returns parsed object when .retro.toml is in the start directory', () => {
+    tempDir.createFile(
+      '.retro.toml',
+      `[retrospective]
+sprint_id = "sprint-42"
+output_dir = "docs/retrospectives"
+
+[[repos]]
+path = "."
+label = "frontend"
+
+[[repos]]
+path = "../api"
+label = "api"
+`
+    );
+
+    const result = findRetroConfig(tempDir.path);
+    expect(result).not.toBeNull();
+    expect(result?.retrospective?.sprint_id).toBe('sprint-42');
+    expect(result?.retrospective?.output_dir).toBe('docs/retrospectives');
+    expect(result?.repos).toHaveLength(2);
+    expect(result?.repos?.[0]).toEqual({ path: '.', label: 'frontend' });
+    expect(result?.repos?.[1]).toEqual({ path: '../api', label: 'api' });
+  });
+
+  test('walks up to find .retro.toml in a parent directory', () => {
+    tempDir.createFile(
+      '.retro.toml',
+      `[retrospective]
+sprint_id = "parent-sprint"
+`
+    );
+    const nested = tempDir.createDir('deep/nested/dir');
+
+    const result = findRetroConfig(nested);
+    expect(result).not.toBeNull();
+    expect(result?.retrospective?.sprint_id).toBe('parent-sprint');
+  });
+
+  test('throws a user-readable error for malformed TOML', () => {
+    tempDir.createFile('.retro.toml', 'this is = = not valid ]]]] toml');
+    expect(() => findRetroConfig(tempDir.path)).toThrow(/Failed to parse/);
+  });
+
+  test('parses empty repos array gracefully (single-repo config-only mode)', () => {
+    tempDir.createFile(
+      '.retro.toml',
+      `[retrospective]
+sprint_id = "solo"
+`
+    );
+    const result = findRetroConfig(tempDir.path);
+    expect(result).not.toBeNull();
+    expect(result?.repos).toBeUndefined();
+  });
+
+  test('defaults startDir to process.cwd() when no arg', () => {
+    // Just verify no crash and returns null|object.
+    const result = findRetroConfig();
+    // We do not make assertions on the value since this depends on the
+    // test runner's cwd; the worktree may itself have a .retro.toml added
+    // by a future change.
+    expect(result === null || typeof result === 'object').toBe(true);
+  });
+
+  test('path field from nested config is relative to file, consumer resolves', () => {
+    // Documenting behavior: findRetroConfig does not resolve repo paths.
+    // That is the consumer's responsibility.
+    tempDir.createFile(
+      '.retro.toml',
+      `[[repos]]
+path = "./sub"
+label = "sub"
+`
+    );
+    const result = findRetroConfig(tempDir.path);
+    expect(result?.repos?.[0]?.path).toBe('./sub');
+  });
+});
+
+// Verify the exported module path also resolves from the root file
+describe('findRetroConfig import shape', () => {
+  test('findRetroConfig is a named export', async () => {
+    const mod = await import('../../src/config.js');
+    expect(typeof mod.findRetroConfig).toBe('function');
+  });
+});
+
+// Use join() to silence unused-import in some environments.
+void join;

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -3,8 +3,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
-import { writeFileSync } from 'fs';
-import { join } from 'path';
 import { createTempDir, type TempDir } from '../helpers/temp-dir.js';
 import { findRetroConfig } from '../../src/config.js';
 
@@ -20,13 +18,10 @@ describe('findRetroConfig', () => {
   });
 
   test('returns null when no .retro.toml exists anywhere up to root', () => {
-    // tmpdir should not contain a .retro.toml all the way up
-    // (this is a best-effort assumption — if one exists in /tmp it would shadow)
-    // Create a nested dir and search from there.
+    // Bound the walk to the temp dir so the result is deterministic regardless
+    // of what ancestor directories the developer/CI environment contains.
     const nested = tempDir.createDir('a/b/c');
-    const result = findRetroConfig(nested);
-    // If any ancestor happens to have a `.retro.toml`, this test would fail.
-    // Under CI / dev environments that is not expected.
+    const result = findRetroConfig(nested, tempDir.path);
     expect(result).toBeNull();
   });
 
@@ -49,11 +44,12 @@ label = "api"
 
     const result = findRetroConfig(tempDir.path);
     expect(result).not.toBeNull();
-    expect(result?.retrospective?.sprint_id).toBe('sprint-42');
-    expect(result?.retrospective?.output_dir).toBe('docs/retrospectives');
-    expect(result?.repos).toHaveLength(2);
-    expect(result?.repos?.[0]).toEqual({ path: '.', label: 'frontend' });
-    expect(result?.repos?.[1]).toEqual({ path: '../api', label: 'api' });
+    expect(result?.config?.retrospective?.sprint_id).toBe('sprint-42');
+    expect(result?.config?.retrospective?.output_dir).toBe('docs/retrospectives');
+    expect(result?.config?.repos).toHaveLength(2);
+    expect(result?.config?.repos?.[0]).toEqual({ path: '.', label: 'frontend' });
+    expect(result?.config?.repos?.[1]).toEqual({ path: '../api', label: 'api' });
+    expect(result?.configDir).toBe(tempDir.path);
   });
 
   test('walks up to find .retro.toml in a parent directory', () => {
@@ -67,7 +63,8 @@ sprint_id = "parent-sprint"
 
     const result = findRetroConfig(nested);
     expect(result).not.toBeNull();
-    expect(result?.retrospective?.sprint_id).toBe('parent-sprint');
+    expect(result?.config?.retrospective?.sprint_id).toBe('parent-sprint');
+    expect(result?.configDir).toBe(tempDir.path);
   });
 
   test('throws a user-readable error for malformed TOML', () => {
@@ -84,21 +81,18 @@ sprint_id = "solo"
     );
     const result = findRetroConfig(tempDir.path);
     expect(result).not.toBeNull();
-    expect(result?.repos).toBeUndefined();
+    expect(result?.config?.repos).toBeUndefined();
   });
 
   test('defaults startDir to process.cwd() when no arg', () => {
     // Just verify no crash and returns null|object.
     const result = findRetroConfig();
-    // We do not make assertions on the value since this depends on the
-    // test runner's cwd; the worktree may itself have a .retro.toml added
-    // by a future change.
     expect(result === null || typeof result === 'object').toBe(true);
   });
 
   test('path field from nested config is relative to file, consumer resolves', () => {
     // Documenting behavior: findRetroConfig does not resolve repo paths.
-    // That is the consumer's responsibility.
+    // That is the consumer's responsibility (cli.ts resolves against configDir).
     tempDir.createFile(
       '.retro.toml',
       `[[repos]]
@@ -107,7 +101,8 @@ label = "sub"
 `
     );
     const result = findRetroConfig(tempDir.path);
-    expect(result?.repos?.[0]?.path).toBe('./sub');
+    expect(result?.config?.repos?.[0]?.path).toBe('./sub');
+    expect(result?.configDir).toBe(tempDir.path);
   });
 });
 
@@ -118,6 +113,3 @@ describe('findRetroConfig import shape', () => {
     expect(typeof mod.findRetroConfig).toBe('function');
   });
 });
-
-// Use join() to silence unused-import in some environments.
-void join;


### PR DESCRIPTION
## Summary

Addresses all 8 issues raised by Copilot in PR #23 review.

- **Config dir resolution** (`config.ts`, `cli.ts`): `findRetroConfig()` now returns `{ config, configDir }`. Relative `[[repos]].path` entries are resolved against the directory containing `.retro.toml`, not `process.cwd()` — fixes silent misresolution when the CLI is invoked from a nested directory.
- **Unsupported fields removed** (`config.ts`): `from`/`to` removed from `RetroToml.retrospective` since they were never wired to `RetroConfig`.
- **Per-repo action-item cap** (`runner.ts`): Action items are now capped at 5 in `runPipelineForRepo()` so embedded per-repo sections also honour the constitution §48 limit (not just the aggregate).
- **H1 heading in multi-repo embed** (`report/generator.ts`): `generateMarkdown()` gains an `includeHeader` flag (default `true`). Multi-repo rendering passes `false` to avoid multiple H1s in the combined document.
- **Test hygiene** (`test/unit/config.test.ts`): Removed unused `writeFileSync`/`join` imports and the `void join` workaround. Added `stopAt` to the "returns null" test to make it deterministic regardless of ancestor-directory contents.
- **Integration test dist dependency** (`test/integration/multi-repo.test.ts`): Added `beforeAll` that runs `pnpm run build` before the CLI smoke test shells out to `node dist/cli.js`, so the test works on fresh clones and in CI.

## Test plan

- [x] `pnpm run validate` — lint + typecheck + all 284 tests pass.
- [x] `pnpm run build` — tsc clean.
- [x] New per-repo action-item cap assertion added to test 7 in `multi-repo.test.ts`.
- [x] Config test assertions updated to `result?.config?.*` new shape.
- [x] "Returns null" config test is now deterministic (uses `stopAt`).

Closes #23 review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)