### PR TITLE
docs: Claude-native telemetry spec + feature PRDs (Codex-validated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 
 # Generated retrospective reports (optional - may want to commit these)
 # docs/retro/
+
+# Third-party repos cloned for research/PRD extraction (read-only, not committed)
+3rd-party/

--- a/docs/prd/features/01-session-telemetry-ingestion.md
+++ b/docs/prd/features/01-session-telemetry-ingestion.md
@@ -1,0 +1,64 @@
+# PRD 01 — Session Telemetry Ingestion
+
+**Tier:** 1 (Foundation). **Status:** Draft. **Depends on:** nothing. **Blocks:** 02–08.
+
+## Problem
+The retrospective reads only `.logs/tools/*.jsonl` from this plugin's own hooks and ignores the
+authoritative Claude session stream under `~/.claude/projects/`. Without ingesting that stream there
+is no objective basis for token, tool, subagent, skill, or MCP metrics.
+
+## Capability
+A read-only ingester that parses Claude session JSONL into the normalized data contract
+(`docs/specs/claude-native-telemetry.md` §3) and exposes it to downstream analyzers. No scoring
+change in this PRD — it produces the dataset everything else consumes.
+
+## Behaviour
+1. **Discovery.** Search `~/.claude/projects`, `~/.config/claude/projects`, and
+   `~/.claude/transcripts`; honor `CLAUDE_CONFIG_DIR` (comma-separated, multiple dirs).
+2. **Streaming parse.** Read JSONL line-by-line; require only a `type` discriminator; skip malformed
+   lines; tolerate unknown fields (forward-compatible with schema drift). Never load whole files into
+   memory unnecessarily.
+3. **Normalize** `user` / `assistant` / `attachment` records into `ClaudeTurn`, and `tool_use` /
+   `tool_result` blocks into `ClaudeToolCall` with tool-target extraction
+   (`Read/Edit/Write→file_path`, `Grep/Glob→pattern`, `Bash→command`, `WebFetch→url`,
+   `Agent`/`Task→subagent_type` — match **both** subagent-launch tool names; the 2.1.150 sample uses
+   `Agent`).
+4. **Resolve subagents.** For each `<session>/subagents/agent-<id>.jsonl`, read its `.meta.json`
+   sidecar and emit a `ClaudeSubagent`. Only `agentType` is guaranteed present; `description` /
+   `toolUseId` are optional (inventory §3.1). When `toolUseId` is present, link to the parent
+   `Agent`/`Task` tool call; when absent, attribute at session level and flag lineage as unknown. Sum
+   the subagent's own deduped usage.
+5. **Resolve externalized tool results.** When a tool result is stored at
+   `<session>/tool-results/<id>.txt`, take result size from the file, not the inline body.
+6. **Deduplicate.** Collapse assistant streaming records by `message.id`, keeping the last record
+   (final usage tally). Streamed partials share `message.id` but each has a distinct `uuid`, so
+   `(sessionId, uuid)` must NOT be used to collapse them (inventory §8) — it is only an identity for
+   records lacking `message.id`. Recompute any totals from the deduped turns — never sum partials.
+7. **Scope.** Filter to sessions whose `gitBranch` / `cwd` / `timestamp` fall in the sprint window
+   resolved from `--from` / `--to` / `--sprint` / `--repo`.
+
+## Data inputs
+Per `docs/research/claude-data-inventory.md`: §2 session record schema, §2.1 `message.usage`, §2.2
+tool attribution, §3 external-storage subdirs (`subagents/`, `tool-results/`).
+
+## Acceptance criteria
+- Given fixture sessions, the ingester emits `ClaudeTurn` / `ClaudeToolCall` / `ClaudeSubagent`
+  records matching the §3 contract.
+- Subagent token totals are attributed to the spawning parent turn via `toolUseId`; a session with
+  subagents reports strictly higher total tokens than a main-stream-only scan.
+- Duplicate streaming records for one `message.id` produce exactly one turn; totals do not
+  double-count (regression test with a known duplicate).
+- Malformed lines and unknown record types do not abort the run.
+- A schema-version guard records the observed `version` and surfaces a warning when it differs from
+  the version the fixtures were captured against.
+
+## Scoring dimensions
+Foundation only — emits the dataset. No direct dimension scoring here.
+
+## Risks
+- Schema drift (inventory §7): pin to observed fields, keep sample fixtures, fail soft.
+- Privacy: session JSONL contains full prompt/response text; never write it outside `.logs/`.
+- Same-basename project collisions during cwd→project resolution (Issue #19).
+
+## Out of scope
+Pricing, attribution rollups, detectors, persistence — later PRDs.

--- a/docs/prd/features/02-token-cost-accounting.md
+++ b/docs/prd/features/02-token-cost-accounting.md
@@ -1,0 +1,52 @@
+# PRD 02 — Token & Cost Accounting
+
+**Tier:** 2. **Status:** Draft. **Depends on:** 01. **Blocks:** report's cost section.
+
+## Problem
+Token usage is the primary signal for "how heavily and how efficiently are we using Claude," but the
+raw stream splits tokens across input / cache-creation / cache-read / output and per-iteration
+breakdowns, and the local `costUSD` field is unpopulated. Without a correct accounting layer, cost
+and efficiency claims are unreliable.
+
+## Capability
+Turn the normalized turns from PRD 01 into a correct token ledger and computed cost, aggregated over
+the sprint window.
+
+## Behaviour
+1. **Per-turn ledger.** For each assistant turn record:
+   - billable input = `input_tokens + cache_creation_input_tokens`
+   - cache read = `cache_read_input_tokens` (billed ~0.1×; treated as whole-session overhead, not
+     attributable to a single tool)
+   - output = `output_tokens`
+   - cache TTL split = `cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens`
+   - server tool use = `server_tool_use.{web_search_requests, web_fetch_requests}`
+2. **Cost.** Compute from tokens × an offline pricing table keyed by model. **Do not** trust
+   `costUSD` from local caches (observed as 0). Guard against fuzzy model-name mismatches and treat a
+   missing price as "unknown," not 0.
+3. **Model registry.** Resolve model identifiers (and aliases) to pricing keys; record unknown models
+   rather than silently dropping them.
+4. **Aggregation.** Roll up by the **sprint window** (git refs), and secondarily by session, by day,
+   by model, by project. Sprint windowing — not fixed rolling clock windows — is the unit of a
+   retrospective.
+
+## Data inputs
+`docs/research/claude-data-inventory.md` §2.1 (`message.usage`), §4 (`stats-cache.json` as an optional
+fast baseline only — recompute from turns when accuracy matters).
+
+## Acceptance criteria
+- Reported billable tokens for a fixture match a hand-computed expected value.
+- Cache-read tokens are reported separately and excluded from per-tool attribution.
+- A turn on an unpriced/unknown model is counted in tokens and flagged as "cost unknown," never
+  priced at 0.
+- Sprint-window totals equal the sum of in-window deduped turns.
+
+## Scoring dimensions
+- **Delivery Predictability:** token/cost trend across the sprint; per-task cost outliers.
+- **Collaboration Efficiency:** cache-read ratio and output/input ratios as efficiency proxies.
+
+## Risks
+- `speed`/`service_tier` pricing tiers (e.g. fast mode) unverified on sample — confirm before pricing.
+- Offline pricing table goes stale; version it and note the "prices as of" date in the report.
+
+## Out of scope
+Attribution to tool/skill/MCP (PRD 03); detectors (PRD 04).

--- a/docs/prd/features/03-source-attribution.md
+++ b/docs/prd/features/03-source-attribution.md
@@ -1,0 +1,51 @@
+# PRD 03 — Source Attribution
+
+**Tier:** 2. **Status:** Draft. **Depends on:** 01, 02.
+
+## Problem
+Knowing total tokens is not actionable. The retrospective needs to answer *what* consumed the
+context: a direct response, a built-in tool, a subagent, a skill, or an MCP server/method. Without
+attribution, there is no lever to pull when spend is high.
+
+## Capability
+Attribute each unit of context spend to its source, and link every user prompt to the tools it
+triggered and the results that re-entered context.
+
+## Behaviour
+1. **Attribution priority** (highest wins) for each spend-bearing event:
+   `MCP method (mcp__*) > subagent (Task) > skill > built-in tool > direct response`.
+   - MCP methods identified by the `mcp__<server>__<method>` tool-name convention.
+   - Subagents launched via the `Agent` or `Task` tool (match both; the 2.1.150 sample uses `Agent`).
+     Subagent spend resolved via the `subagents/*.meta.json` `toolUseId` link when present
+     (deterministic; no fragile text heuristics); when the sidecar lacks `toolUseId`, attribute at
+     session level and flag lineage unknown.
+   - Skill invocation identified from the skill-execution marker; capture the skill identity
+     explicitly (a known gap in naive implementations is counting skill firings without recording
+     *which* skill).
+   - Guard against false positives when scanning text markers (e.g. em-dash / literal `--` lines).
+2. **Prompt → tool → result → token linkage.** Walk the `parentUuid` chain so each user prompt maps
+   to the assistant turns, tool calls, and tool-result sizes that followed, and the tokens they cost.
+   This is the "what burned the context for this prompt" map.
+3. **Rollups.** Aggregate spend by source category and by specific identity (which tool, which
+   subagent type, which skill, which MCP method) over the sprint window.
+
+## Data inputs
+`docs/research/claude-data-inventory.md` §2.2 (tool attribution), §3.1 (subagent lineage),
+`ClaudeToolCall` / `ClaudeSubagent` from PRD 01.
+
+## Acceptance criteria
+- A fixture with an MCP call, a subagent, a skill, and a Bash call attributes each to the correct
+  category with the documented priority.
+- Subagent tokens attribute to the spawning prompt, not to "direct response."
+- Skill attribution records the specific skill identity, not just a count.
+- For a given prompt, the tool/result/token linkage reconstructs the full causal chain.
+
+## Scoring dimensions
+- **Collaboration Efficiency:** spend-by-source breakdown; identifies over-reliance on broad
+  subagents, expensive MCP methods, or over-firing skills.
+
+## Risks
+- Attribution markers are schema-dependent; re-verify against the live install per inventory §7.
+
+## Out of scope
+Waste classification (PRD 04) — this PRD attributes; it does not judge.

--- a/docs/prd/features/03-source-attribution.md
+++ b/docs/prd/features/03-source-attribution.md
@@ -13,7 +13,7 @@ triggered and the results that re-entered context.
 
 ## Behaviour
 1. **Attribution priority** (highest wins) for each spend-bearing event:
-   `MCP method (mcp__*) > subagent (Task) > skill > built-in tool > direct response`.
+   `MCP method (mcp__*) > subagent (Agent/Task) > skill > built-in tool > direct response`.
    - MCP methods identified by the `mcp__<server>__<method>` tool-name convention.
    - Subagents launched via the `Agent` or `Task` tool (match both; the 2.1.150 sample uses `Agent`).
      Subagent spend resolved via the `subagents/*.meta.json` `toolUseId` link when present

--- a/docs/prd/features/04-waste-efficiency-detection.md
+++ b/docs/prd/features/04-waste-efficiency-detection.md
@@ -1,0 +1,54 @@
+# PRD 04 — Waste & Efficiency Detection
+
+**Tier:** 3. **Status:** Draft. **Depends on:** 01, 02, 03.
+
+## Problem
+Counting tokens shows where the fire is, not why it started. A retrospective needs actionable,
+evidence-linked findings: specific patterns that wasted context or signalled inefficient
+collaboration, each with a remediation.
+
+## Capability
+A registry of rule-based detectors that scan the normalized turns and emit `ClaudeFinding` records
+(`docs/specs/claude-native-telemetry.md` §3): `{detector, severity, evidence, estimatedWasteTokens?,
+dimension, remediation}`. Each detector is a small, independent, pure function with configurable
+thresholds.
+
+## Detectors (initial set)
+| Detector | Pattern | Remediation hint |
+|---|---|---|
+| Giant tool output | A single tool result far above a byte/token threshold | Cap output; request narrower results |
+| Repeated file reads | Same file read N+ times in a session | Read once; rely on cached context |
+| Tool / Bash overuse | One tool dominates a session's calls | Batch or restructure the workflow |
+| Thrash | Rapid alternation between a small set of files/tools | Step back and plan before editing |
+| Error storm | A burst of tool errors in a short span | Fix root cause before retrying |
+| Retry storm | Repeated near-identical failing calls | Add a stop condition; change approach |
+| One-shot failure | High-cost turn that produced an immediately discarded result | Right-size the request |
+| Skill over-firing | A skill triggers far more often than it produces value | Tighten the skill's trigger |
+| Model substitution | Heavy task run on an under/over-powered model | Match model to task complexity |
+| Cost outlier | A session/project far above the cohort baseline | Investigate the outlier turn |
+
+## Behaviour
+- **Interface:** `Detector.run(stats, baseline?) => Finding[]`. Detectors take normalized,
+  aggregated stats (and an optional cohort baseline) and return findings; no I/O inside detectors.
+- **Evidence:** every finding cites `sessionId + uuid` (or `toolUseId`) — never a vague claim.
+- **Thresholds:** configurable; ship conservative defaults; document that defaults are uncalibrated
+  on small samples and should be tuned.
+
+## Data inputs
+Normalized turns/tool-calls/subagents from PRD 01; attribution from PRD 03; cost from PRD 02.
+
+## Acceptance criteria
+- Each detector has a fixture that triggers it and one that does not (true/false positive control).
+- Every emitted finding carries a resolvable evidence reference.
+- Disabling a detector or changing its threshold via config changes output deterministically.
+
+## Scoring dimensions
+- **Collaboration Efficiency:** giant output, repeated reads, overuse, thrash, skill over-firing.
+- **Quality & Maintainability:** error storm, one-shot failure.
+- **Delivery Predictability:** model substitution, cost outlier.
+
+## Risks
+- Threshold calibration; ship as advisory until validated on a real cohort.
+
+## Out of scope
+Git-outcome correlation (PRD 05); asset utilization (PRD 06).

--- a/docs/prd/features/05-delivery-correlation.md
+++ b/docs/prd/features/05-delivery-correlation.md
@@ -1,0 +1,49 @@
+# PRD 05 — Delivery Correlation
+
+**Tier:** 3. **Status:** Draft. **Depends on:** 01; joins the existing git analyzer.
+
+## Problem
+Telemetry alone says how much was spent, not whether the spend *shipped*. The highest-value
+retrospective signal ties Claude activity to delivery outcomes: was the work kept, reverted, or
+abandoned, and how many edit→verify cycles did it take?
+
+## Capability
+Correlate normalized Claude telemetry with git history to classify productive vs reverted vs
+abandoned work, and count verification loops.
+
+## Behaviour
+1. **Yield classification.** For commits in the sprint window, classify as:
+   - *productive* — kept through to the tip,
+   - *reverted* — later undone (detect via revert commits, e.g. `This reverts commit <sha>`),
+   - *abandoned* — on a branch never merged.
+   Attribute the telemetry spend in the window against each class to produce a "yield" ratio
+   (spend that shipped vs spend that was undone).
+2. **Edit → verify → edit retry counter.** Within a session, count sequences where an edit is
+   followed by a verification step (test/build/lint run) and then another edit to the same target —
+   a proxy for how many cycles correctness took.
+3. **Rework signal.** Use repeated rewrites of the same file (from session activity and/or the
+   per-session file-history snapshots) as a corroborating rework indicator.
+
+## Data inputs
+Normalized turns/tool-calls from PRD 01; the existing git analyzer (`src/analyzers/git.ts`); optional
+`~/.claude/file-history/<sessionId>/` (inventory §1).
+
+## Acceptance criteria
+- A fixture repo with a revert is classified as *reverted* and its window spend counted against
+  reverted yield.
+- An edit→test→edit sequence on one file increments the retry counter; an edit→test (passing, no
+  re-edit) does not.
+- Findings cite the commit SHA and the session/turn evidence.
+
+## Scoring dimensions
+- **Delivery Predictability:** shipped-vs-reverted yield.
+- **Test Loop Completeness:** edit→verify→edit retry counts; presence of verification steps.
+- **Quality & Maintainability:** rework via repeated rewrites.
+
+## Risks
+- Revert detection misses non-standard revert workflows (squash, force-push); document the heuristic.
+- Mapping a commit to the telemetry that produced it is approximate (time/branch correlation), not
+  exact; present as correlation, not causation.
+
+## Out of scope
+Decision rationale (Decision Hygiene) — sourced from `.logs/decisions/`, not git.

--- a/docs/prd/features/06-config-asset-utilization.md
+++ b/docs/prd/features/06-config-asset-utilization.md
@@ -1,0 +1,46 @@
+# PRD 06 — Configuration & Asset Utilization
+
+**Tier:** 3. **Status:** Draft. **Depends on:** 01, 03.
+
+## Problem
+Installed agents, skills, slash-commands, and MCP servers are widely understood to consume context
+budget through their definitions and tool schemas whether or not they are used — though the exact
+per-prompt overhead is not directly observable in the session stream and must be treated as an
+estimate until confirmed against the loaded system context. "Ghost assets" (installed but never
+invoked) are a likely source of silent, recurring waste that token totals alone never reveal.
+
+## Capability
+Cross-reference the configured/installed asset inventory against what actually fired during the
+sprint, and report utilization gaps.
+
+## Behaviour
+1. **Inventory.** Enumerate configured assets from local config:
+   `~/.claude/agents/`, `~/.claude/skills/`, `~/.claude/commands/`, MCP servers from
+   `settings.json`, and project `CLAUDE.md` includes (inventory §1).
+2. **Invocation set.** From attribution (PRD 03), collect the set of agents/subagent-types, skills,
+   commands, and MCP methods that actually fired in the window.
+3. **Gap report.**
+   - *Ghost assets:* installed but never invoked → candidates to prune or lazy-load.
+   - *MCP coverage:* MCP servers/methods loaded vs invoked; flag large loaded-but-unused surfaces
+     (deferred-tool inventories that bloat every prompt).
+4. **Cost framing.** Where the per-prompt overhead of an asset can be estimated, attach an estimated
+   recurring token cost to each ghost asset to prioritize pruning.
+
+## Data inputs
+Local config dirs (inventory §1); invocation set from PRD 03.
+
+## Acceptance criteria
+- A fixture with an installed-but-unused skill reports it as a ghost asset; an installed-and-used
+  skill is not flagged.
+- MCP loaded-vs-invoked report lists methods present in config but absent from the invocation set.
+- Each ghost-asset finding cites the config source that declares it.
+
+## Scoring dimensions
+- **Collaboration Efficiency:** prune unused assets to cut recurring per-prompt overhead.
+
+## Risks
+- An asset unused in one sprint may be valuable in others; present as advisory, scoped to the window.
+- Per-prompt overhead estimation is approximate without token-level accounting of system context.
+
+## Out of scope
+Detector findings on usage patterns (PRD 04) — this PRD is about *installed vs used*, not *how used*.

--- a/docs/prd/features/07-durable-telemetry-ledger.md
+++ b/docs/prd/features/07-durable-telemetry-ledger.md
@@ -1,0 +1,45 @@
+# PRD 07 — Durable Telemetry Ledger
+
+**Tier:** 4. **Status:** Draft. **Depends on:** 01, 02.
+
+## Problem
+Claude prunes session JSONL on a rolling retention window. A retrospective that only reads the live
+logs cannot compute trends across sprints, because older data silently disappears. Trend tracking
+(Issue #18) requires durable, deduplicated history under our own control.
+
+## Capability
+Snapshot normalized, deduplicated telemetry into a local store that is the source of truth for
+historical aggregates and trends, surviving Claude's log rotation.
+
+## Behaviour
+1. **Store.** Persist normalized turns / tool-calls / subagents / findings into a local store
+   (SQLite recommended) with uniqueness constraints (e.g. `(sessionId, message_id)`) so re-ingesting
+   the same data is idempotent.
+2. **Idempotent merge.** Use insert-or-ignore semantics; recompute aggregates from stored rows, never
+   additively, so re-runs and overlapping windows do not double-count.
+3. **Incremental scan.** Track per-file mtime / line counts to skip unchanged files on re-ingest.
+4. **History preservation.** Once stored, retain rows beyond Claude's rolling window so cross-sprint
+   trends remain computable.
+5. **Optional hook-driven ingestion.** Provide a Stop-hook entry (wired through this plugin's
+   `hooks/hooks.json`) that ingests after each response, keeping the store current without a manual
+   run. Opt-in.
+
+## Data inputs
+Normalized output of PRD 01/02; persisted under `.logs/` (gitignored).
+
+## Acceptance criteria
+- Re-ingesting the same sessions twice yields identical aggregates (idempotency test).
+- A trend query spans sprints whose source JSONL is no longer present, using stored rows.
+- Incremental re-scan skips unchanged files (verified by a no-op second run).
+- The optional Stop-hook is opt-in and a no-op when disabled.
+
+## Scoring dimensions
+Enables **trend** views across sprints for all dimensions; no new scoring of its own.
+
+## Risks
+- **Privacy:** the store may contain prompt/response text; it must live under `.logs/` (gitignored)
+  and never be committed. Document a retention/redaction option.
+- Store schema versioning as the normalized model evolves.
+
+## Out of scope
+The normalized model itself (PRD 01); report rendering.

--- a/docs/prd/features/08-transcript-evidence-export.md
+++ b/docs/prd/features/08-transcript-evidence-export.md
@@ -1,0 +1,47 @@
+# PRD 08 — Transcript Evidence & Export
+
+**Tier:** 4. **Status:** Draft. **Depends on:** 01.
+
+## Problem
+Aggregates tell you *where* cost concentrated; they do not show *why* a prompt or workflow caused it.
+The "no AI slop" rule requires that any finding can be traced back to the actual transcript, and a
+qualitative review pass benefits from a compact, readable rendering of prior sessions.
+
+## Capability
+Reconstruct human-readable transcripts from the normalized stream and export a compact form suitable
+for qualitative review and for feeding prior sessions back into a model for meta-analysis.
+
+## Behaviour
+1. **Reconstruction.** Build the conversation order from the `parentUuid` / `uuid` linked list (a
+   DAG), repairing broken parent chains where possible, and render turns (prompt, thinking, tool
+   calls, results, response) in sequence.
+2. **Summary prioritization.** Title a session by the model-generated `ai-title` record when present,
+   falling back to the first user prompt.
+3. **Evidence linkage.** Given a finding's `sessionId + uuid`, render the exact surrounding turns so a
+   reviewer can read the cause in context.
+4. **Compact export.** Emit a compact Markdown rendering (configurable detail level) that strips noise
+   and merges adjacent low-signal turns — small enough to feed back into a model for meta-analysis of
+   prompt patterns and failure loops.
+5. **Filters.** Support date / session / project filters aligned with the sprint window.
+
+## Data inputs
+Normalized turns from PRD 01; `ai-title` record (inventory §2); `history.jsonl` as a lightweight
+prompt index (inventory §5).
+
+## Acceptance criteria
+- A fixture session reconstructs in correct causal order, including across a broken parent link.
+- Session title uses `ai-title` when present, else the first prompt.
+- Given a finding reference, the tool renders the cited turn ± context.
+- The compact export of a large session is materially smaller than the full transcript and remains
+  coherent.
+
+## Scoring dimensions
+- **All dimensions (qualitative support):** supplies the evidence excerpts that back findings; surfaces
+  reusable prompt patterns and "misunderstood X" failure loops for the retrospective narrative.
+
+## Risks
+- **Privacy:** transcripts contain full text; exports must stay under `.logs/` (gitignored) and never
+  be committed.
+
+## Out of scope
+Quantitative scoring (PRDs 02–06).

--- a/docs/research/claude-data-inventory.md
+++ b/docs/research/claude-data-inventory.md
@@ -1,0 +1,220 @@
+# Claude Code Local Data Inventory
+
+**Purpose:** Authoritative, primary-source catalog of the telemetry available under `~/.claude/`
+for the agentic-retrospective tool. Every entry was verified against a live install on
+**Claude Code version `2.1.150`** (field present in session records as `version`). Schema is
+versioned and undocumented by Anthropic; treat every field as best-effort and parse defensively.
+
+**Verification date:** 2026-05-24. **Sample host:** single user, ~172 project slugs, 404 sessions,
+213,813 messages (`~/.claude/stats-cache.json`), `projects/` ≈ 391 MB.
+
+> ⚠️ **Version drift is the central risk.** The session format is undocumented and versioned; several
+> assumptions that held on older versions are **stale on 2.1.150** — see [§7 Schema drift](#7-schema-drift).
+> Verify against this inventory before implementing.
+
+---
+
+## 1. Directory map of `~/.claude/`
+
+| Path | Type | Contains | Retro value |
+|---|---|---|---|
+| `projects/<slug>/<session>.jsonl` | JSONL | Full per-session event stream (prompts, assistant turns, tool calls, usage) | **Primary source.** Token use, tool/skill/MCP attribution, prompts, decisions |
+| `projects/<slug>/<session>/subagents/agent-<agentId>.jsonl` | JSONL | Full transcript of each spawned subagent | **Subagent cost attribution** (current schema) |
+| `projects/<slug>/<session>/subagents/agent-<agentId>.meta.json` | JSON | sidecar; `agentType` always present, `description`/`toolUseId`/`name`/`worktreePath` optional (§3.1) | **Lineage join when `toolUseId` present**; else session-level attribution |
+| `projects/<slug>/<session>/tool-results/<id>.txt` | text | Externalized large tool-result bodies, referenced by path from the JSONL | Accurate tool-result size; inline-only estimation under-counts |
+| `projects/<slug>/memory/` | dir | Per-project agent memory (this repo's auto-memory) | Out of scope for usage metrics |
+| `stats-cache.json` | JSON | Pre-aggregated lifetime stats (see §4) | Fast cross-project baseline without reparsing |
+| `history.jsonl` | JSONL | Prompt/command history per project+session (see §5) | Lightweight prompt index, command-vs-prompt classification |
+| `sessions/<pid>.json` | JSON | Live process metadata per session pid (see §6) | Session start/cwd/version/entrypoint |
+| `telemetry/1p_failed_events.*.json` | JSONL | Failed first-party telemetry events (multi-object files) | Error/instrumentation signal; low priority |
+| `audit.jsonl` | JSONL | `{timestamp, tool, session, cwd}` audit records (sparse on sample) | Minimal; mostly `Unknown` tool |
+| `file-history/<sessionId>/` | dir | Per-session file backups/snapshots | Rework signal (files repeatedly rewritten) |
+| `settings.json` / `settings.local.json` | JSON | User + local config (model, hooks, permissions) | Config-aware detectors (ghost-asset detection) |
+| `agents/`, `skills/`, `commands/`, `plugins/` | dirs | Installed agents/skills/commands/plugins | "Ghost asset" detection (loaded but never invoked) |
+| `tasks/<uuid>/`, `teams/`, `session-env/` | dirs | Background-task / team / per-session env state | Out of scope (runtime, not retro telemetry) |
+| `shell-snapshots/`, `paste-cache/`, `cache/`, `backups/` | dirs | Transient caches | Out of scope |
+
+> **Note:** Depending on version and install, Claude data may also live under
+> `~/.config/claude/projects/` and `~/.claude/transcripts/`. On the sample host only
+> `~/.claude/projects/` exists, but a portable ingester must search all three and honor
+> `CLAUDE_CONFIG_DIR` (see §3).
+
+---
+
+## 2. Session JSONL record schema (`projects/<slug>/<session>.jsonl`)
+
+Each line is one JSON object discriminated by `type`. Observed `type` values on 2.1.150:
+
+| `type` | Meaning | Key fields |
+|---|---|---|
+| `user` | User prompt OR tool_result carrier | `message.role`, `message.content` (string for prompts; array of `tool_result` blocks otherwise), `promptId`, `uuid`, `parentUuid`, `cwd`, `gitBranch`, `version`, `timestamp` |
+| `assistant` | One assistant API response | `message.model`, `message.usage` (see §2.1), `message.content[]` (blocks: `text`, `thinking`, `tool_use`), `requestId`, `uuid`, `parentUuid`, `advisorModel` (when advisor used) |
+| `attachment` | Hook output, injected files, system events | `attachment.type` (`hook_success`, `hook_non_blocking_error`, `file`, …), `attachment.hookName`, `attachment.durationMs`, `toolUseID` |
+| `file-history-snapshot` | File backup checkpoint | `messageId`, `snapshot.trackedFileBackups`, `snapshot.timestamp` |
+| `last-prompt` | Pointer to most recent prompt leaf | `leafUuid`, `sessionId` |
+| `permission-mode` | Permission mode change | `permissionMode` (e.g. `bypassPermissions`), `sessionId` |
+| `ai-title` | Model-generated session title | `aiTitle`, `sessionId` |
+
+Common envelope fields on `user`/`assistant`/`attachment`: `parentUuid` (linked-list to prior record),
+`isSidechain` (bool), `sessionId`, `cwd`, `gitBranch`, `version`, `entrypoint` (`cli`), `userType`
+(`external`), `timestamp` (ISO-8601).
+
+### 2.1 `message.usage` (assistant records) — the token ledger
+
+Verified live object:
+
+```json
+{
+  "input_tokens": 7985,
+  "cache_creation_input_tokens": 19186,
+  "cache_read_input_tokens": 0,
+  "output_tokens": 1066,
+  "server_tool_use": { "web_search_requests": 0, "web_fetch_requests": 0 },
+  "service_tier": "standard",
+  "cache_creation": { "ephemeral_1h_input_tokens": 19186, "ephemeral_5m_input_tokens": 0 },
+  "inference_geo": "",
+  "iterations": [ { "input_tokens": 7985, "output_tokens": 1066, "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 19186, "type": "message" } ],
+  "speed": "standard"
+}
+```
+
+Field meaning for cost/accounting:
+- **Billable input** = `input_tokens + cache_creation_input_tokens`.
+- **Cache read** = `cache_read_input_tokens` — billed at ~0.1× and is whole-session overhead, **not**
+  attributable to a single tool.
+- **Cache TTL split** = `cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens`.
+- **`service_tier` / `speed`** = `standard` vs other tiers; affects pricing. A `speed=="fast"` value
+  was **not** present on the sample (`speed` was `"standard"`); confirm before relying on it.
+- **`server_tool_use`** = server-side web_search / web_fetch counts (billed separately).
+- **`iterations[]`** = per-API-iteration breakdown within one logical turn (new; prior tools sum the
+  top-level fields and ignore this).
+
+### 2.2 Tool attribution
+
+- `assistant` records contain `tool_use` blocks: `{type:"tool_use", id:"toolu_…", name, input}`.
+  Tool-target extraction: `Read/Edit/Write → input.file_path`,
+  `Grep/Glob → input.pattern`, `Bash → input.command`, `WebFetch → input.url`,
+  `Agent`/`Task → input.subagent_type`.
+- `user` records carry matching `tool_result` blocks: `{type:"tool_result", tool_use_id, is_error}`.
+  **Result body may be externalized** to `tool-results/<id>.txt` (§3.2) — size must be read from disk,
+  not estimated from the inline JSONL line.
+- Subagents are spawned via the **`Agent`** tool with `input.subagent_type` — **verified**: 12 `Agent`
+  launches and 0 `Task` in the 2.1.150 sample session. (`Task` is the documented spawn tool in some
+  Claude Code builds.) **An ingester must match both `Agent` and `Task`.** Do not rely on a top-level
+  `toolUseID` for lineage; use the subagent sidecar instead (§3.1).
+
+---
+
+## 3. External-storage subdirectories (current schema, 2.1.150)
+
+These are the biggest divergence from older schema expectations and the highest-value accuracy fix.
+
+### 3.1 `subagents/agent-<agentId>.jsonl` + `.meta.json`
+
+Each spawned subagent gets its own full transcript file plus a sidecar:
+
+```json
+// agent-a1a325a3335f7fea7.meta.json  (fullest observed form)
+{ "agentType": "general-purpose", "description": "<subagent task description>",
+  "toolUseId": "toolu_01A9LgbyzU8DDRnizoq4RST4" }
+```
+
+- **Field presence is variable** — only `agentType` is universal. Verified across 351 local
+  `.meta.json` files: `agentType` only (120), `+description` (99), `+description +toolUseId` (73),
+  `+description +name` (42), and combinations with `name` / `worktreePath`. **Treat `description`,
+  `toolUseId`, `name`, `worktreePath` as optional.**
+- When present, the sidecar's `toolUseId` links the subagent file → the spawning `Agent`/`Task`
+  tool_use block in the parent session, giving **deterministic lineage** without a two-pass tool-use-ID
+  heuristic. **When `toolUseId` is absent, lineage is unknown** — attribute the subagent's spend at the
+  session level and flag it, rather than guessing a parent.
+- Subagent records carry `agentId`, `promptId`, `isSidechain:true`, and their own `message.usage` —
+  so subagent token cost is summed (deduped) from the subagent file, then attributed to the parent
+  turn via the sidecar when available. (Verified: one subagent emitted 8,647 output tokens.)
+- **Consequence:** a usage total that scans only `<session>.jsonl` and ignores `subagents/`
+  **undercounts** all subagent spend. A "scan one dir" approach misses this.
+
+### 3.2 `tool-results/<id>.txt`
+
+Large tool-result bodies are written to disk and referenced by path from the JSONL
+(`grep` confirmed `tool-results/bqyti0sz3.txt` referenced inline). A `chars/4` estimate over the
+inline body will under-count these results; size must come from the `.txt` file.
+
+---
+
+## 4. `stats-cache.json` — pre-aggregated lifetime stats
+
+Top-level keys: `version, lastComputedDate, dailyActivity, dailyModelTokens, modelUsage,
+totalSessions, totalMessages, longestSession, firstSessionDate, hourCounts,
+totalSpeculationTimeSavedMs`.
+
+`modelUsage[<model>]` carries `inputTokens, outputTokens, cacheReadInputTokens,
+cacheCreationInputTokens, webSearchRequests, costUSD, contextWindow, maxOutputTokens`.
+On the sample host `costUSD` was `0` for all models (not populated) — **do not trust it for cost**;
+compute cost from tokens × offline pricing.
+
+Value: a near-instant baseline (lifetime totals, daily activity, hour-of-day distribution) without
+reparsing 391 MB of JSONL. Caveat: it is a cache Claude maintains; treat as a convenience projection,
+recompute from JSONL when accuracy matters.
+
+---
+
+## 5. `history.jsonl` — prompt/command index
+
+Record: `{display, pastedContents, timestamp (epoch ms), project (abs path), sessionId}`.
+`display` is the prompt or slash-command text (e.g. `"config"`). Useful as a lightweight,
+cross-project prompt index and to classify slash-commands vs free-text prompts without parsing
+full sessions.
+
+---
+
+## 6. `sessions/<pid>.json` — process metadata
+
+Record: `{pid, sessionId, cwd, startedAt (epoch ms), procStart, version, peerProtocol, kind
+(e.g. "interactive"), entrypoint}`. Maps OS pids → sessionId and gives authoritative start time,
+cwd, and entrypoint per session. Useful for cwd→project resolution and session timing.
+
+---
+
+## 7. Schema drift
+
+Assumptions that held on older versions but are **stale on 2.1.150**. Verify against this inventory.
+
+| Legacy assumption | Status on 2.1.150 | Correct current approach |
+|---|---|---|
+| Subagents spawned via one fixed tool name | **Build-dependent** — `Agent` observed in 2.1.150 sample (12 launches, 0 `Task`); `Task` documented elsewhere | Match **both** `Agent` and `Task`; read `subagents/*.meta.json` `toolUseId` for lineage |
+| `.meta.json` always carries `description` + `toolUseId` | **Stale** — only `agentType` is universal (73/351 had all three) | Treat lineage fields as optional; session-level attribution when `toolUseId` absent |
+| Top-level `toolUseID` for sidechain labeling | **Absent** at top level | Use `subagents/` files + `.meta.json` sidecar |
+| Sidechains inline in main JSONL (`isSidechain:true`) | **Moved out** — 0 inline on sample; live in `subagents/` | Scan `subagents/agent-*.jsonl` |
+| Tool-result size = inline body length | **Partial** — large results externalized | Resolve `tool-results/<id>.txt` |
+| `usage.speed == "fast"` for fast-mode cost | **Not observed** (`speed:"standard"`) | Verify before relying; treat as optional |
+| `costUSD` populated in stats/usage | **Zero** on sample | Compute from tokens × offline pricing |
+| Single data dir under `~/.claude/projects` | Incomplete — also `~/.config/claude`, `transcripts/` | Multi-dir discovery + `CLAUDE_CONFIG_DIR` |
+| `.meta.json` subagent sidecar | **Confirmed present** | Use it as the lineage source of truth |
+| `advisorModel` / `iterations[]` fields | **New** on 2.1.150 | New signals available; not yet consumed |
+
+---
+
+## 8. Deduplication requirement
+
+Assistant streaming emits multiple partial records that share one `message.id` but each carry a
+**distinct `uuid`**. **Verified:** in the 2.1.150 sample, 54 of 84 `message.id`s spanned more than one
+`uuid` (one spanned 4). Naive summation double-counts, and **`(sessionId, uuid)` does NOT collapse
+these duplicates** — each streamed partial has its own `uuid`. The correct approach: dedup on
+**`message.id`** (keep the **last** record, which holds the final usage tally) and recompute session
+totals from the deduped turns. `(sessionId, uuid)` is only a fallback identity for records that lack a
+`message.id` entirely — not a streaming-dedup key. Any retrospective ingester must do the same.
+
+---
+
+## 9. What is NOT in local data (gaps for scoring)
+
+The token/session telemetry above informs **Collaboration Efficiency** and **Delivery Predictability**
+well, but the local `~/.claude/` data alone does **not** contain:
+- Decision rationale/context → the retrospective's own `.logs/decisions/` (Decision Hygiene).
+- Test pass/fail outcomes → CI logs / git (Test Loop Completeness).
+- Security findings → security scanners / `.logs/` (Security Posture).
+- Commit/PR linkage (shipped vs reverted) → git (a yield correlation bridges telemetry↔git).
+
+These dimensions require joining Claude telemetry with git/CI/decision sources the retrospective
+already analyzes. See the consolidated spec, `docs/specs/claude-native-telemetry.md`.

--- a/docs/research/claude-data-inventory.md
+++ b/docs/research/claude-data-inventory.md
@@ -37,7 +37,8 @@ versioned and undocumented by Anthropic; treat every field as best-effort and pa
 > **Note:** Depending on version and install, Claude data may also live under
 > `~/.config/claude/projects/` and `~/.claude/transcripts/`. On the sample host only
 > `~/.claude/projects/` exists, but a portable ingester must search all three and honor
-> `CLAUDE_CONFIG_DIR` (see §3).
+> `CLAUDE_CONFIG_DIR`, if set, as the override for the base Claude config/data directory
+> when resolving `projects/`.
 
 ---
 
@@ -49,7 +50,7 @@ Each line is one JSON object discriminated by `type`. Observed `type` values on 
 |---|---|---|
 | `user` | User prompt OR tool_result carrier | `message.role`, `message.content` (string for prompts; array of `tool_result` blocks otherwise), `promptId`, `uuid`, `parentUuid`, `cwd`, `gitBranch`, `version`, `timestamp` |
 | `assistant` | One assistant API response | `message.model`, `message.usage` (see §2.1), `message.content[]` (blocks: `text`, `thinking`, `tool_use`), `requestId`, `uuid`, `parentUuid`, `advisorModel` (when advisor used) |
-| `attachment` | Hook output, injected files, system events | `attachment.type` (`hook_success`, `hook_non_blocking_error`, `file`, …), `attachment.hookName`, `attachment.durationMs`, `toolUseID` |
+| `attachment` | Hook output, injected files, system events | `attachment.type` (`hook_success`, `hook_non_blocking_error`, `file`, …), `attachment.hookName`, `attachment.durationMs`, `attachment.toolUseID` (attachment-local; not a top-level envelope field) |
 | `file-history-snapshot` | File backup checkpoint | `messageId`, `snapshot.trackedFileBackups`, `snapshot.timestamp` |
 | `last-prompt` | Pointer to most recent prompt leaf | `leafUuid`, `sessionId` |
 | `permission-mode` | Permission mode change | `permissionMode` (e.g. `bypassPermissions`), `sessionId` |

--- a/docs/specs/claude-native-telemetry.md
+++ b/docs/specs/claude-native-telemetry.md
@@ -1,0 +1,171 @@
+# Spec: Claude-Native Telemetry for agentic-retrospective
+
+**Status:** Draft for review. Implementation deferred to downstream PRs (one per accepted feature).
+**Inputs:** `docs/research/claude-data-inventory.md` (primary-source schema), `docs/prd/features/*`
+(feature PRDs).
+**Scope:** Defines *what* Claude telemetry the retrospective should ingest and *which* capabilities
+to build. Does not specify implementation code.
+
+---
+
+## 1. Problem & goal
+
+Today `src/analyzers/tools.ts` reads only `.logs/tools/*.jsonl` emitted by this plugin's own hooks.
+It ignores the authoritative Claude-native stream under `~/.claude/projects/`, so the retrospective
+cannot answer "how are we actually using Claude — tokens, tools, subagents, skills, MCP, waste?"
+with evidence.
+
+**Goal:** Add a Claude-native ingestion path that produces an evidence-linked telemetry dataset for a
+sprint (bounded by git refs, per the existing `--from`/`--to`/`--sprint` CLI surface), feeding the
+existing 6 scoring dimensions. Every metric must trace to a `sessionId + uuid` (or `agentId`) in a
+specific JSONL record — the "no AI slop" rule.
+
+---
+
+## 2. Design principles
+
+1. **Separate ingestion from reporting.** Normalize raw JSONL into a stable internal shape once; run
+   many projections (by tool, subagent, skill, MCP, session, day, model).
+2. **Durable, deduped ledger.** Claude prunes JSONL on a rolling window; snapshot into a local store
+   with uniqueness constraints so sprint history survives. Dedup assistant streaming records by
+   `message.id`; recompute totals from deduped turns — never additively.
+3. **Defensive parsing.** Require only a `type` discriminator; tolerate unknown fields and schema
+   drift; skip malformed lines without aborting.
+4. **Verify schema against the live install.** The session format is undocumented and versioned;
+   re-target subagent lineage to `subagents/` + `.meta.json`, and resolve externalized
+   `tool-results/*.txt` (see inventory §3, §7).
+5. **Evidence linkage over aggregates.** Keep the path back to the transcript so a finding can cite
+   the prompt/turn that caused it.
+6. **Classify waste, don't just count tokens.** Rule-based detectors over normalized turns produce
+   actionable findings, which is what a retrospective needs.
+
+---
+
+## 3. Data contract (the normalized internal model)
+
+A future `claude-native` analyzer must emit these record shapes (names indicative, not binding). All
+token fields follow the inventory §2.1 definitions.
+
+```
+ClaudeTurn {
+  sessionId, uuid, parentUuid, role: 'user'|'assistant',
+  model?, timestamp, gitBranch, cwd, projectSlug,
+  usage?: { inputTokens, cacheCreationTokens, cacheReadTokens, outputTokens,
+            serviceTier, speed, serverToolUse: {webSearch, webFetch} },
+  isSidechain, agentId?           // agentId present for subagent turns
+}
+
+ClaudeToolCall {
+  sessionId, turnUuid, toolUseId, name,
+  target,                         // file_path|pattern|command|url|subagent_type per tool (inventory §2.2)
+  resultBytes,                    // resolved from inline body OR tool-results/<id>.txt
+  isError
+}
+
+ClaudeSubagent {
+  agentId, agentType,              // from subagents/agent-<id>.meta.json; agentType always present
+  description?,                    // optional (sidecar fields vary; inventory §3.1)
+  spawnedByToolUseId?,             // optional — links to parent Agent/Task tool_use; absent => lineage unknown
+  usageTotals                      // summed (deduped) from subagents/agent-<id>.jsonl
+}
+
+ClaudeFinding {              // waste/efficiency detector output
+  detector, severity, evidence: { sessionId, uuid|toolUseId },
+  estimatedWasteTokens?, dimension, remediation
+}
+```
+
+**Dedup key:** `message.id`, keep the last record (streamed partials share `message.id` but each has a
+distinct `uuid`, so `(sessionId, uuid)` does NOT collapse duplicates — use it only as an identity for
+records lacking `message.id`; inventory §8). **Subagent launch tool:** match both `Agent` and `Task`
+(inventory §2.2). **Discovery:** search
+`~/.claude/projects`, `~/.config/claude/projects`, `~/.claude/transcripts`, honor `CLAUDE_CONFIG_DIR`
+(comma-separated). **Scope filter:** restrict to sessions whose `gitBranch`/`cwd`/timestamp fall in
+the sprint window resolved from `--from`/`--to`/`--sprint`/`--repo`.
+
+---
+
+## 4. Capabilities
+
+Eight capabilities, each detailed in its own PRD under `docs/prd/features/`. Grouped into four
+build tiers by dependency order.
+
+### Tier 1 — Foundation
+
+| Capability | PRD | Summary |
+|---|---|---|
+| Session telemetry ingestion | `01-session-telemetry-ingestion.md` | Defensive streaming JSONL parser → normalized, deduped model; multi-dir discovery; subagent + tool-result resolution; sprint-window scoping |
+
+### Tier 2 — Accounting & attribution
+
+| Capability | PRD | Summary |
+|---|---|---|
+| Token & cost accounting | `02-token-cost-accounting.md` | Per-turn token ledger (input/cache-create/cache-read/output); offline pricing; model registry; sprint-windowed aggregation |
+| Source attribution | `03-source-attribution.md` | Attribute context spend to MCP / subagent / skill / tool / direct; prompt→tool→result→token linkage |
+
+### Tier 3 — Findings (the retrospective payload)
+
+| Capability | PRD | Summary |
+|---|---|---|
+| Waste & efficiency detection | `04-waste-efficiency-detection.md` | Rule-based detectors over normalized turns: repeated reads, giant outputs, error/retry storms, tool overuse, skill over-firing, cost outliers |
+| Delivery correlation | `05-delivery-correlation.md` | Tie telemetry to git outcomes: shipped-vs-reverted yield, edit→verify→edit retry loops |
+| Configuration & asset utilization | `06-config-asset-utilization.md` | Detect loaded-but-unused agents/skills/commands/MCP; MCP loaded-vs-invoked coverage |
+
+### Tier 4 — Durability & qualitative review
+
+| Capability | PRD | Summary |
+|---|---|---|
+| Durable telemetry ledger | `07-durable-telemetry-ledger.md` | Persist deduped snapshots past Claude's rolling retention; optional hook-driven ingestion |
+| Transcript evidence & export | `08-transcript-evidence-export.md` | Reconstruct transcripts via parentUuid DAG; compact Markdown export for qualitative review; summary prioritization |
+
+---
+
+## 5. Mapping to the 6 scoring dimensions
+
+| Dimension | Strongest telemetry signals | Capabilities |
+|---|---|---|
+| **Collaboration Efficiency** | Tool/subagent/skill/MCP attribution; waste detectors; ghost assets; repeated reads | 03, 04, 06 |
+| **Delivery Predictability** | Token/cost trend; model substitution; cost outliers; shipped-vs-reverted yield | 02, 04, 05 |
+| **Test Loop Completeness** | edit→verify→edit retries; test-command patterns; error→fix loops | 04, 05 |
+| **Quality & Maintainability** | Error storms; one-shot failure; rework via repeated file rewrites | 04 |
+| **Decision Hygiene** | ⚠️ Not in `~/.claude/` data — join with `.logs/decisions/` (existing analyzer) | — |
+| **Security Posture** | ⚠️ Not in `~/.claude/` data — join with security scanners / `.logs/` | — |
+
+Honest gap: pure token telemetry serves Collaboration Efficiency and Delivery Predictability well;
+Decision Hygiene and Security Posture require joining Claude telemetry with the retrospective's
+existing decision-log and security analyzers. Do not synthesize those dimensions from token data.
+
+---
+
+## 6. Prioritized roadmap (downstream PRs)
+
+Each is a separate PR gated by review of this spec and the relevant feature PRD.
+
+1. **PR-1 (Tier 1):** Parser + normalized model + dedup + subagent/tool-result resolution. Read-only;
+   emits the §3 data contract. Unit tests against fixture JSONL. No scoring change yet.
+2. **PR-2 (Tier 2):** Accounting + attribution + offline pricing + sprint-window aggregation. Adds a
+   `claude-native` section to the report.
+3. **PR-3 (Tier 3):** Waste/efficiency detectors and asset-utilization findings feeding Collaboration
+   Efficiency; delivery correlation feeding Delivery Predictability & Test Loop Completeness.
+4. **PR-4 (Tier 4):** Durable snapshot store + optional hook-driven ingestion + compact transcript
+   export. Wires into `hooks/hooks.json`.
+
+Each PR: update `tools.ts` or add a sibling analyzer (decide in PR-1's plan), keep
+`plugin.json`/`marketplace.json`/`README.md` in sync if CLI/scoring surface changes, log decisions to
+`.logs/decisions/`.
+
+---
+
+## 7. Open risks
+
+- **Schema drift.** The observed install version already diverges from older expectations
+  (inventory §7). Pin parsing to observed fields, add a schema-version guard, and snapshot sample
+  fixtures so drift is caught by tests.
+- **`speed`/`service_tier` pricing.** Fast-mode field not observed on the sample; confirm before
+  pricing fast turns.
+- **`costUSD` is 0** in `stats-cache.json` — never trust it; compute from tokens.
+- **Privacy.** Session JSONL contains full prompt/response text. Snapshots and compact exports must
+  stay under `.logs/` (gitignored) and never be committed.
+- **Same-basename project collisions** (Issue #19) when resolving cwd→project.
+- **Detector thresholds** are uncalibrated on a small sample; make them configurable and validate
+  before shipping findings as authoritative.

--- a/docs/specs/claude-native-telemetry.md
+++ b/docs/specs/claude-native-telemetry.md
@@ -48,11 +48,12 @@ token fields follow the inventory §2.1 definitions.
 
 ```
 ClaudeTurn {
-  sessionId, uuid, parentUuid, role: 'user'|'assistant',
+  sessionId, uuid, parentUuid, kind: 'message'|'attachment',
+  role?: 'user'|'assistant',      // present for kind: 'message'; omitted for attachments
   model?, timestamp, gitBranch, cwd, projectSlug,
   usage?: { inputTokens, cacheCreationTokens, cacheReadTokens, outputTokens,
             serviceTier, speed, serverToolUse: {webSearch, webFetch} },
-  isSidechain, agentId?           // agentId present for subagent turns
+  isSidechain, agentId?           // agentId present for subagent turns; attachments normalize here too
 }
 
 ClaudeToolCall {


### PR DESCRIPTION
## Problem
The retrospective captures telemetry only from `.logs/tools/*.jsonl` emitted by this plugin's own hooks (`src/analyzers/tools.ts`). It ignores the authoritative Claude session stream under `~/.claude/projects/`, so it cannot objectively report how Claude is actually used — tokens, tools, subagents, skills, MCP, waste, or delivery yield.

## Approach
Docs-only research package that defines *what* Claude telemetry to ingest and *which* capabilities to build, before any implementation. Features are described on their own merits (no third-party tool coupling).

**Added:**
- `docs/research/claude-data-inventory.md` — primary-source catalog of `~/.claude/` data: session record schema, `message.usage` token fields, subagent (`subagents/*.meta.json`) and external tool-result (`tool-results/*.txt`) storage, and schema-drift notes. Verified against a live install (version 2.1.150).
- `docs/specs/claude-native-telemetry.md` — consolidated spec: design principles, normalized data contract, 8 capabilities, 6-dimension mapping, and a 4-PR roadmap.
- `docs/prd/features/01-08` — one generic capability PRD each: session ingestion, token & cost accounting, source attribution, waste detection, delivery correlation, asset utilization, durable ledger, transcript export.

## Tracking issues (generic descriptions)
Epic #44 — capabilities #36, #37, #38, #39, #40, #41, #42, #43. Implementation is deferred to per-tier PRs gated by these issues and the spec.

## Scope / non-goals
- No source or behavior change; no analyzer implemented in this PR.
- Decision Hygiene and Security Posture are explicitly out of scope for token telemetry — they join the existing decision-log/security analyzers.

## Validation
Producer: Claude Opus 4.7. Validator: **Codex (GPT-5, cross-provider)** — verdict **APPROVE-WITH-CHANGES**, all 4 required changes applied **before** opening this PR (this supersedes the closed #45):
1. Subagent launch tool is `Agent` (verified 12 launches, 0 `Task`, in the 2.1.150 sample) — match both `Agent` and `Task`; removed the incorrect "Agent is stale" claim.
2. `.meta.json` lineage fields are optional (only `agentType` universal; 73/351 files had all three) — session-level attribution when `toolUseId` absent.
3. Dedup must key on `message.id` (streamed partials share `message.id` but carry distinct `uuid`s; verified 54/84) — `(sessionId, uuid)` is not a dedup key.
4. Spec PR-3 dimension wording aligned with PRD 06 (asset-utilization → Collaboration Efficiency).

Codex confirmed the core schema claims (`message.usage` fields, externalized `tool-results/*.txt`, subagent JSONL files, `message.id` dedup) against real local data.

## Test evidence
Docs-only change — no source/test files touched, so `pnpm run validate` has nothing to gate. Verified no third-party tool names or `3rd-party/` paths appear in committed docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
