### PR TITLE
ci(runners): route CI jobs to self-hosted runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Route CI jobs to the self-hosted runner pool, matching the daax-web reference (`runs-on: self-hosted`), so PRs stop consuming GitHub-hosted Actions minutes.

Supersedes the earlier `ci/self-hosted-default-group` PR, which used `runs-on: { group: Default }` — that syntax left jobs queued for 14h+ on some repos. This uses the proven daax-web label form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)